### PR TITLE
[WIP] Add a runner template

### DIFF
--- a/runners/mlcommons_box_template_runner/mlcommons_box_runner.yaml
+++ b/runners/mlcommons_box_template_runner/mlcommons_box_runner.yaml
@@ -1,0 +1,25 @@
+schema_version: 0.1.0
+schema_type: mlcommons_box_runner
+
+platform:
+  # type of platform the runner supports
+  type: PLATFORM_NAME
+  # the platform versions that the runner can support
+  # a runner should check version compatibility between the mlbox,
+  # the runner and the platform
+  version_filter:
+    min: null
+    max: null
+    good_list: []
+    bad_list: []
+config_options:
+  # the exec_types lists the supported spec format in which the runner can
+  # specify how to execute an action. each item in the list corresponds to
+  # a pre-defiend schema which can be used to validate an exec spec.
+  exec_types:
+  - "cli"
+  # the actions that the runner can take, the actions are used as
+  # runner subcommand
+  actions:
+  - "configure"
+  - "run"

--- a/runners/mlcommons_box_template_runner/mlcommons_box_template_runner/main.py
+++ b/runners/mlcommons_box_template_runner/mlcommons_box_template_runner/main.py
@@ -1,0 +1,9 @@
+from mlcommons_box_template_runner import template_runner
+
+
+def main():
+    runner = template_runner.TemplateRunner()
+    runner.run()
+
+if __name__ == "__main__":
+    main()

--- a/runners/mlcommons_box_template_runner/mlcommons_box_template_runner/template_runner.py
+++ b/runners/mlcommons_box_template_runner/mlcommons_box_template_runner/template_runner.py
@@ -1,0 +1,9 @@
+from mlcommons_box.runner import base_runner
+
+class TemplateRunner(base_runner.BaseRunner):
+
+    def action_configure(self, args):
+        raise NotImplementedError
+
+    def action_run(self, args):
+        raise NotImplementedError

--- a/runners/mlcommons_box_template_runner/setup.py
+++ b/runners/mlcommons_box_template_runner/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name = "mlcommons-box-template-runner",
+    version = "0.1.0",
+    description = "MLCommons Box Template Runner",
+    packages = find_packages(include="mlcommons_box_template_runner"),
+    package_data = {"mlcommons_box_template_runner":["mlcommons_box_runner.yaml"]},
+    include_package_data = True,
+    entry_points = {
+        "console_scripts": ["mlcbr-template = mlcommons_box_template_runner.main:main"]
+    }
+)


### PR DESCRIPTION
This adds a template runner, which serves as a template for custom runners. The template runner is provided for convenience of new runner development only, it cannot be used as an actual runner.

part of runner spec implementation #66 
depends on #73
closes #68
 