### PR TITLE
[WIP] Support for docker run parameters

### DIFF
--- a/docs/getting-started/mnist.md
+++ b/docs/getting-started/mnist.md
@@ -246,11 +246,15 @@ Since we wanted to support Docker and Singularity runtimes, we provide `docker.y
 the `platforms` subdirectory that is default location to store these types of files. Docker platform configuration is
 the following:
 ```yaml
-schema_version: 1.0.0
-schema_type: mlbox_docker
+schema_type: mlcommons_box_platform
+schema_version: 0.1.0
 
-image: mlperf/mlbox:mnist   # Docker image name
-docker_runtime: docker      # Docker executable: docker or nvidia-docker
+platform:
+  name: "docker"
+  version: ">=18.01"
+configuration:
+  image: "mlperf/mlbox:mnist"
+  parameters: "--rm --net=host --privileged=true"
 
 ```
 

--- a/examples/hello_world/platforms/docker.yaml
+++ b/examples/hello_world/platforms/docker.yaml
@@ -4,6 +4,6 @@ schema_version: 0.1.0
 platform:
   name: "docker"
   version: ">=18.01"
-container:
+configuration:
   image: "mlperf/mlbox:hello_world"
   parameters: "--rm --net=host --privileged=true"

--- a/examples/hello_world/platforms/docker.yaml
+++ b/examples/hello_world/platforms/docker.yaml
@@ -6,3 +6,4 @@ platform:
   version: ">=18.01"
 container:
   image: "mlperf/mlbox:hello_world"
+  parameters: "--rm --net=host --privileged=true"

--- a/examples/mnist/platforms/docker.yaml
+++ b/examples/mnist/platforms/docker.yaml
@@ -4,6 +4,6 @@ schema_version: 0.1.0
 platform:
   name: "docker"
   version: ">=18.01"
-container:
+configuration:
   image: "mlperf/mlbox:mnist"
   parameters: "--rm --net=host --privileged=true"

--- a/examples/mnist/platforms/docker.yaml
+++ b/examples/mnist/platforms/docker.yaml
@@ -6,3 +6,4 @@ platform:
   version: ">=18.01"
 container:
   image: "mlperf/mlbox:mnist"
+  parameters: "--rm --net=host --privileged=true"

--- a/mlcommons_box/mlcommons_box/common/objects/__init__.py
+++ b/mlcommons_box/mlcommons_box/common/objects/__init__.py
@@ -1,15 +1,12 @@
 import logging
-import os
-
 import yaml
-
 from mlcommons_box.common.objects import base
+
 
 logger = logging.getLogger(__name__)
 
 
-def load_object_from_file(file_path: str,
-                          obj_class: base.BaseObject) -> base.BaseObject:
+def load_object_from_file(file_path: str, obj_class: callable) -> base.BaseObject:
     """Load an object from a yaml file.
 
     Args:

--- a/mlcommons_box/mlcommons_box/common/objects/base.py
+++ b/mlcommons_box/mlcommons_box/common/objects/base.py
@@ -1,10 +1,8 @@
 import abc
-import collections
 import logging
-import os
-import typing
-
+from typing import (Any)
 import mlspeclib
+
 
 logger = logging.getLogger(__name__)
 
@@ -12,26 +10,24 @@ logger = logging.getLogger(__name__)
 class BaseField(abc.ABC):
 
     @abc.abstractmethod
-    def get_default_value(self):
+    def get_default_value(self) -> Any:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_value_from_primitive(self,
-            primitive: typing.Any=None) -> typing.Any:
+    def get_value_from_primitive(self, primitive: Any = None) -> Any:
         raise NotImplementedError
 
 
 class ObjectField(BaseField):
 
-    def __init__(self, obj_class: 'BaseObject'):
+    def __init__(self, obj_class: callable) -> None:
         self.object_class = obj_class
 
     def get_default_value(self) -> 'BaseObject':
         instance = self.object_class().default()
         return instance
 
-    def get_value_from_primitive(self,
-            primitive: typing.Any=None) -> 'BaseObject':
+    def get_value_from_primitive(self, primitive: Any = None) -> 'BaseObject':
         instance = self.object_class()
         instance.from_primitive(primitive=primitive)
         return instance
@@ -39,14 +35,13 @@ class ObjectField(BaseField):
 
 class PrimitiveField(BaseField):
 
-    def __init__(self, default: typing.Any=None):
+    def __init__(self, default: Any = None) -> None:
         self.default_value = default
 
-    def get_default_value(self) -> typing.Any:
+    def get_default_value(self) -> Any:
         return self.default_value
 
-    def get_value_from_primitive(self,
-            primitive: typing.Any=None) -> typing.Any:
+    def get_value_from_primitive(self, primitive: Any = None) -> Any:
         instance = self.get_default_value()
         if primitive is not None:
             instance = primitive
@@ -57,7 +52,7 @@ class BaseObject(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def validate(cls, primitive: typing.Any) -> bool:
+    def validate(cls, primitive: Any) -> bool:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -65,8 +60,7 @@ class BaseObject(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def from_primitive(self,
-            primitive: typing.Any) -> 'BaseObject':
+    def from_primitive(self, primitive: Any) -> 'BaseObject':
         raise NotImplementedError
 
 
@@ -79,14 +73,15 @@ class StandardObject(BaseObject):
     schema = {}
 
     @classmethod
-    def validate(cls, primitive: typing.Any) -> bool:
+    def validate(cls, primitive: Any) -> bool:
         if not isinstance(primitive, dict):
             return False
         mlobject = mlspeclib.MLObject()
         mlobject.set_type(
             schema_type=cls.SCHEMA_TYPE,
-            schema_version="1.0.0") # this is the mlspec-schema version and
-                                    # not this object's schema version
+            # This is the mlspec-schema version and not this object's schema version
+            schema_version="1.0.0"
+        )
         mlspeclib.MLObject.update_tree(mlobject, primitive)
         errors = mlobject.validate()
         if errors:
@@ -102,7 +97,7 @@ class StandardObject(BaseObject):
             setattr(self, fld_name, attr)
         return self
 
-    def from_primitive(self, primitive: typing.Any) -> 'StandardObject':
+    def from_primitive(self, primitive: Any) -> 'StandardObject':
         if not self.validate(primitive):
             raise ValueError("Validation failed for {}".format(
                     self.__class__.__name__))
@@ -124,7 +119,9 @@ class ListOfObject(BaseObject):
         super(ListOfObject, self).__init__()
 
     def __repr__(self): return repr(self._data)
+
     def __len__(self): return len(self._data)
+
     def __getitem__(self, i):
         if isinstance(i, slice):
             return self.__class__(self._data[i])
@@ -132,7 +129,7 @@ class ListOfObject(BaseObject):
             return self._data[i]
 
     @classmethod
-    def validate(cls, primitive: typing.Any) -> bool:
+    def validate(cls, primitive: Any) -> bool:
         if not isinstance(primitive, list):
             return False
         for item in primitive:
@@ -145,7 +142,7 @@ class ListOfObject(BaseObject):
         self._data = []
         return self
 
-    def from_primitive(self, primitive: typing.Any) -> 'ListOfObject':
+    def from_primitive(self, primitive: Any) -> 'ListOfObject':
         if not self.validate(primitive):
             raise ValueError("Validation failed for {}".format(
                     self.__class__.__name__))
@@ -165,7 +162,9 @@ class DictOfObject(BaseObject):
         super(DictOfObject, self).__init__()
 
     def __repr__(self): return repr(self._data)
+
     def __len__(self): return len(self._data)
+
     def __getitem__(self, key):
         if key in self._data:
             return self._data[key]
@@ -174,7 +173,7 @@ class DictOfObject(BaseObject):
         raise KeyError(key)
 
     @classmethod
-    def validate(cls, primitive: typing.Any) -> bool:
+    def validate(cls, primitive: Any) -> bool:
         if not isinstance(primitive, dict):
             return False
         for key, value in primitive.items():
@@ -187,7 +186,7 @@ class DictOfObject(BaseObject):
         self._data = {}
         return self
 
-    def from_primitive(self, primitive: typing.Any) -> 'DictOfObject':
+    def from_primitive(self, primitive: Any) -> 'DictOfObject':
         if not self.validate(primitive):
             raise ValueError("Validation failed for {}".format(
                     self.__class__.__name__))

--- a/mlcommons_box/mlcommons_box/common/objects/platform_config.py
+++ b/mlcommons_box/mlcommons_box/common/objects/platform_config.py
@@ -6,8 +6,8 @@ class Container(base.StandardObject):
     SCHEMA_TYPE = "mlcommons_box_platform_container"
     SCHEMA_VERSION = "0.1.0"
     fields = {
-        "runtime": base.PrimitiveField(),
-        "image": base.PrimitiveField()
+        "image": base.PrimitiveField(),
+        "parameters": base.PrimitiveField()
     }
 
 

--- a/mlcommons_box/mlcommons_box/common/objects/platform_config.py
+++ b/mlcommons_box/mlcommons_box/common/objects/platform_config.py
@@ -3,6 +3,7 @@ from mlcommons_box.common.objects import common
 
 
 class Container(base.StandardObject):
+    """ Generic configuration for container-based platforms such as Docker and Singularity. """
     SCHEMA_TYPE = "mlcommons_box_platform_container"
     SCHEMA_VERSION = "0.1.0"
     fields = {
@@ -12,9 +13,20 @@ class Container(base.StandardObject):
 
 
 class PlatformConfig(base.StandardObject):
+    """ Generic platform configuration for MLCommons-Box runners. """
     SCHEMA_TYPE = "mlcommons_box_platform"
     SCHEMA_VERSION = "0.1.0"
     fields = {
         "platform": base.ObjectField(common.PlatformMetadata),
-        "container": base.ObjectField(Container)
+        "configuration": base.DictOfObject()
+    }
+
+
+class ContainerPlatformConfig(base.StandardObject):
+    """ Generic platform configuration for container-based runners. """
+    SCHEMA_TYPE = "mlcommons_box_platform"
+    SCHEMA_VERSION = "0.1.0"
+    fields = {
+        "platform": base.ObjectField(common.PlatformMetadata),
+        "configuration": base.ObjectField(Container)
     }

--- a/mlcommons_box/mlcommons_box/schemas/mlbox-platform-container.yaml
+++ b/mlcommons_box/mlcommons_box/schemas/mlbox-platform-container.yaml
@@ -5,18 +5,19 @@ mlspec_schema_type:
   meta: mlcommons_box_platform_container
 
 schema_version:
-  # User previded: Identifies version of mlbox_input to use
+  # User provided: Identifies version of mlbox_input to use
   type: semver
   required: True
 
 schema_type:
-  # User previded: Identifies that this is a mlbox_input
+  # User provided: Identifies that this is a mlbox_input
   type: string
   required: True
-
-runtime:
-  type: string
 
 image:
   type: string
   required: True
+
+parameters:
+  type: string
+  required: False

--- a/mlcommons_box/mlcommons_box/schemas/mlbox-platform-metadata.yaml
+++ b/mlcommons_box/mlcommons_box/schemas/mlbox-platform-metadata.yaml
@@ -5,12 +5,12 @@ mlspec_schema_type:
   meta: mlcommons_box_platform_metadata
 
 schema_version:
-  # User previded: Identifies version of mlbox_input to use
+  # User provided: Identifies version of mlbox_input to use
   type: semver
   required: True
 
 schema_type:
-  # User previded: Identifies that this is a mlbox_input
+  # User provided: Identifies that this is a mlbox_input
   type: string
   required: True
 

--- a/mlcommons_box/mlcommons_box/schemas/mlbox-platform.yaml
+++ b/mlcommons_box/mlcommons_box/schemas/mlbox-platform.yaml
@@ -5,12 +5,12 @@ mlspec_schema_type:
   meta: mlcommons_box_platform
 
 schema_version:
-  # User previded: Identifies version of mlbox_input to use
+  # User provided: Identifies version of mlbox_input to use
   type: semver
   required: True
 
 schema_type:
-  # User previded: Identifies that this is a mlbox_input
+  # User provided: Identifies that this is a mlbox_input
   type: string
   required: True
 
@@ -18,6 +18,6 @@ platform:
   type: dict
   required: True
 
-container:
+configuration:
   type: dict
   required: True

--- a/runners/mlcommons_box_docker/mlcommons_box_docker/__main__.py
+++ b/runners/mlcommons_box_docker/mlcommons_box_docker/__main__.py
@@ -22,7 +22,8 @@ def cli():
 def configure(mlbox: str, platform: str):
     mlbox: mlbox_metadata.MLBox = mlbox_metadata.MLBox(path=mlbox)
     mlbox.platform = objects.load_object_from_file(
-            file_path=platform, obj_class=platform_config.PlatformConfig)
+        file_path=platform, obj_class=platform_config.ContainerPlatformConfig
+    )
     print(mlbox)
 
     runner = DockerRun(mlbox)
@@ -36,7 +37,8 @@ def configure(mlbox: str, platform: str):
 def run(mlbox: str, platform: str, task: str):
     mlbox: mlbox_metadata.MLBox = mlbox_metadata.MLBox(path=mlbox)
     mlbox.platform = objects.load_object_from_file(
-            file_path=platform, obj_class=platform_config.PlatformConfig)
+            file_path=platform, obj_class=platform_config.ContainerPlatformConfig
+    )
     mlbox.invoke = mlbox_metadata.MLBoxInvoke(task)
     mlbox.task = mlbox_metadata.MLBoxTask(os.path.join(mlbox.tasks_path, f'{mlbox.invoke.task_name}.yaml'))
     print(mlbox)

--- a/runners/mlcommons_box_docker/mlcommons_box_docker/docker_run.py
+++ b/runners/mlcommons_box_docker/mlcommons_box_docker/docker_run.py
@@ -25,7 +25,7 @@ class DockerRun(object):
 
     def configure(self) -> None:
         """Build Docker Image on a current host."""
-        image_name: str = self.mlbox.platform.container.image
+        image_name: str = self.mlbox.platform.configuration.image
 
         # According to MLBox specs (?), build directory is {mlbox.root}/build that contains all files to build MLBox.
         # Dockerfiles are built taking into account that {mlbox.root}/build is the context (build) directory.
@@ -46,14 +46,15 @@ class DockerRun(object):
         print(f"mounts={mounts}, args={args}")
 
         volumes_str = ' '.join(['--volume {}:{}'.format(t[0], t[1]) for t in mounts.items()])
-        image_name: str = self.mlbox.platform.container.image
-        container_params: str = self.mlbox.platform.container.parameters
+        image_name: str = self.mlbox.platform.configuration.image
+        container_params: str = self.mlbox.platform.configuration.parameters
         if container_params is None or container_params == '':
             container_params = "--rm --net=host --privileged=true"
         env_args = ' '.join([f"-e {var}={name}" for var, name in DockerRun.get_env_variables().items()])
 
         # Let's assume singularity containers provide entry point in the right way.
-        cmd = f"docker run {container_params} {volumes_str} {env_args} {image_name} {' '.join(args)}"
+        docker_runner = self.mlbox.platform.platform.name
+        cmd = f"{docker_runner} run {container_params} {volumes_str} {env_args} {image_name} {' '.join(args)}"
         logger.info(cmd)
         DockerRun.run_or_die(cmd)
 


### PR DESCRIPTION
This commit introduces support for custom docker `run` parameters in the platform configuration file and proposes a slightly different way to configure platforms (== runners).


### Refactoring platform configuration files
In the current  version, a platform configuration file is supposed to provide two mandatory sections - `platform` and `container`. This is targeted for container-based platforms (docker and singularity), and does not fit very well other platforms such as SSH, K8S and GCP. This commit proposes to rename `container` section to `configuration`:
```yaml
platform:
    name: "docker"
    version: ">=18.01"
configuration:
    image: "mlperf/mlbox:hello_world"
    parameters: "--rm --net=host --privileged=true"
```
At the python level, the `PlatformConfig` class can be used for general-purpose configurations. The type of the configuration section is dictionary. Runners can provide their specific configuration objects. For instance, this commit introduces a new class `ContainerPlatformConfig` for container-based platforms.


### Used docker `run` parameters.
Users can specify MLBox-specific docker `run` parameters. A new field named `parameters` is introduced in the container configuration section. This field is optional. If it is not present, null or empty default value is used: `--rm --net=host --privileged=true`. The exact default value is to be discussed. Current value is what was used in the previous implementation.


### Docker executable
The `name` field in the platform section is used not only to specify the platform, but also as a docker executable. Thus, for docker platforms, valid values are `docker` and `nvidia-docker`. This may not be a good solution, a better option could be to have separate field in the configuration section.

### Other updates
- Updating MNIST and Hello World examples (platform configuration files and documentation pages).
- Updating typing annotations to remove some of the python warnings.