### PR TITLE
SSH runner updates.

### DIFF
--- a/runners/mlcube_ssh/mlcube_ssh/__init__.py
+++ b/runners/mlcube_ssh/mlcube_ssh/__init__.py
@@ -1,0 +1,1 @@
+from mlcube_ssh.__main__ import (configure, run)

--- a/runners/mlcube_ssh/mlcube_ssh/__main__.py
+++ b/runners/mlcube_ssh/mlcube_ssh/__main__.py
@@ -6,7 +6,7 @@ from mlcube_ssh import ssh_metadata
 from mlcube_ssh.ssh_run import SSHRun
 
 
-def configure_(mlcube: str, platform: str):
+def configure(mlcube: str, platform: str):
     mlcube: mlcube_metadata.MLCube = mlcube_metadata.MLCube(path=mlcube)
     mlcube.platform = ssh_metadata.Platform(path=platform)
     print(mlcube)
@@ -15,7 +15,7 @@ def configure_(mlcube: str, platform: str):
     runner.configure()
 
 
-def run_(mlcube: str, platform: str, task: str):
+def run(mlcube: str, platform: str, task: str):
     mlcube: mlcube_metadata.MLCube = mlcube_metadata.MLCube(path=mlcube)
     mlcube.platform = ssh_metadata.Platform(path=platform)
     mlcube.invoke = mlcube_metadata.MLCubeInvoke(task)
@@ -37,16 +37,16 @@ def cli():
 @cli.command(name='configure', help='Configure remote environment for MLCube ML workload.')
 @click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
 @click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
-def configure(mlcube: str, platform: str):
-    configure_(mlcube, platform)
+def configure_cli(mlcube: str, platform: str):
+    configure(mlcube, platform)
 
 
 @cli.command(name='run', help='Run MLCube ML workload in the remote environment.')
 @click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
 @click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
 @click.option('--task', required=True, type=click.Path(exists=True), help='Path to MLCube Task definition file.')
-def run(mlcube: str, platform: str, task: str):
-    run_(mlcube, platform, task)
+def run_cli(mlcube: str, platform: str, task: str):
+    run(mlcube, platform, task)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Unifying `configure`/`run` function names across different runners. CLI functions with click wrappers have `cli` suffix: `configure_cli` and `run_cli`. They call regular worker `configure`/`run` functions.
- Exporting these two functions so that they can be imported as `from mlcube_ssh import configure, run`. This is used by mlcube for implementing single entry point functionality.

This is a series of PR proposing similar updates for all runners:
- SSH #157
- Singularity #158 
- Docker #159
- K8S #160