### PR TITLE
Singularity runner updates.

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/__init__.py
+++ b/runners/mlcube_singularity/mlcube_singularity/__init__.py
@@ -1,0 +1,1 @@
+from mlcube_singularity.__main__ import (configure, run)

--- a/runners/mlcube_singularity/mlcube_singularity/__main__.py
+++ b/runners/mlcube_singularity/mlcube_singularity/__main__.py
@@ -1,24 +1,12 @@
 import os
 import click
 from mlcube import parse   # Do not remove (it registers schemas on import)
-from mlcube.common import mlcube_metadata
 from mlcube.common import objects
+from mlcube.common import mlcube_metadata
 from mlcube.common.objects import platform_config
 from mlcube_singularity.singularity_run import SingularityRun
 
 
-@click.group(name='mlcube_singularity')
-def cli():
-    """
-    MLCube Singularity Runner runs cubes (packaged Machine Learning (ML) workloads) in the singularity
-    environment.
-    """
-    pass
-
-
-@cli.command(name='configure', help='Configure singularity environment for MLCube ML workload.')
-@click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
-@click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
 def configure(mlcube: str, platform: str):
     mlcube: mlcube_metadata.MLCube = mlcube_metadata.MLCube(path=mlcube)
     mlcube.platform = objects.load_object_from_file(file_path=platform, obj_class=platform_config.PlatformConfig)
@@ -28,10 +16,6 @@ def configure(mlcube: str, platform: str):
     runner.configure()
 
 
-@cli.command(name='run', help='Run MLCube ML workload in the singularity environment.')
-@click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
-@click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
-@click.option('--task', required=True, type=click.Path(exists=True), help='Path to MLCube Task definition file.')
 def run(mlcube: str, platform: str, task: str):
     mlcube: mlcube_metadata.MLCube = mlcube_metadata.MLCube(path=mlcube)
     mlcube.platform = objects.load_object_from_file(file_path=platform, obj_class=platform_config.PlatformConfig)
@@ -41,6 +25,29 @@ def run(mlcube: str, platform: str, task: str):
 
     runner = SingularityRun(mlcube)
     runner.run()
+
+
+@click.group(name='mlcube_singularity')
+def cli():
+    """
+    MLCube Singularity Runner runs cubes (packaged Machine Learning (ML) workloads) in the singularity environment.
+    """
+    pass
+
+
+@cli.command(name='configure', help='Configure singularity environment for MLCube ML workload.')
+@click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
+@click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
+def configure_cli(mlcube: str, platform: str):
+    configure(mlcube, platform)
+
+
+@cli.command(name='run', help='Run MLCube ML workload in the singularity environment.')
+@click.option('--mlcube', required=True, type=click.Path(exists=True), help='Path to MLCube directory.')
+@click.option('--platform', required=True, type=click.Path(exists=True), help='Path to MLCube Platform definition file.')
+@click.option('--task', required=True, type=click.Path(exists=True), help='Path to MLCube Task definition file.')
+def run_cli(mlcube: str, platform: str, task: str):
+    run(mlcube, platform, task)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Unifying `configure`/`run` function names across different runners. CLI functions with click wrappers have `cli` suffix: `configure_cli` and `run_cli`. They call regular worker `configure`/`run` functions.
- Exporting these two functions so that they can be imported as `from mlcube_singularity import configure, run`. This is used by mlcube for implementing single entry point functionality.

This is a series of PR proposing similar updates for all runners:
- SSH #157
- Singularity #158 
- Docker #159
- K8S #160