### PR TITLE
K8S runner updates.

### DIFF
--- a/runners/mlcube_k8s/mlcube_k8s/__init__.py
+++ b/runners/mlcube_k8s/mlcube_k8s/__init__.py
@@ -1,0 +1,1 @@
+from mlcube_k8s.main import (configure, run)

--- a/runners/mlcube_k8s/mlcube_k8s/tests/test_mlcube_k8s_cli.py
+++ b/runners/mlcube_k8s/mlcube_k8s/tests/test_mlcube_k8s_cli.py
@@ -8,4 +8,4 @@ def test_mlcube_k8s():
     response = runner.invoke(cli)
     assert response.exit_code == 0
     assert 'Usage: mlcube_k8s [OPTIONS] COMMAND [ARGS]...' in response.output
-    assert "  run  Runs a MLCube in a Kubernetes cluster." in response.output
+    assert "Runs a MLCube in a Kubernetes cluster." in response.output


### PR DESCRIPTION
- Unifying `configure`/`run` function names across different runners. CLI functions with click wrappers have `cli` suffix: `configure_cli` and `run_cli`. They call regular worker `configure`/`run` functions.
- Exporting these two functions so that they can be imported as `from mlcube_k8s import configure, run`. This is used by mlcube for implementing single entry point functionality.
- Adding dummy implementation for the `configure` action.


This is a series of PR proposing similar updates for all runners:
- SSH #157
- Singularity #158 
- Docker #159
- K8S #160