### PR TITLE
Support for docker arguments [WIP].

### DIFF
--- a/mlcube/mlcube/common/objects/platform_config.py
+++ b/mlcube/mlcube/common/objects/platform_config.py
@@ -6,8 +6,10 @@ class Container(base.StandardObject):
     SCHEMA_TYPE = "mlcube_platform_container"
     SCHEMA_VERSION = "0.1.0"
     fields = {
-        "runtime": base.PrimitiveField(),
-        "image": base.PrimitiveField()
+        "runtime": base.PrimitiveField(),    # Runtime should be deprecated.
+        "command": base.PrimitiveField(),    # Executable (docker/nvidia-docker/podman).
+        "run_args": base.PrimitiveField(),   # Arguments for "docker run" excluding image name and MLCube mount points.
+        "image": base.PrimitiveField()       # Name of a docker image.
     }
 
 

--- a/mlcube/mlcube/schemas/mlcube-platform-container.yaml
+++ b/mlcube/mlcube/schemas/mlcube-platform-container.yaml
@@ -5,16 +5,22 @@ mlspec_schema_type:
   meta: mlcube_platform_container
 
 schema_version:
-  # User previded: Identifies version of mlcube_input to use
+  # User provided: Identifies version of mlcube_input to use
   type: semver
   required: True
 
 schema_type:
-  # User previded: Identifies that this is a mlcube_input
+  # User provided: Identifies that this is a mlcube_input
   type: string
   required: True
 
 runtime:
+  type: string
+
+command:
+  type: string
+
+run_args:
   type: string
 
 image:


### PR DESCRIPTION
With this commit, it becomes possible to provide docker arguments and docker executable for docker runner (podman can be used too). This update proposes the following:
- Deprecate `runtime` parameter.
- Introduce `command` parameter. Example values are docker, nvidia-docker and podman.
- Introduce `run_args` parameter that defines parameters for `docker run` command.

Example platform configuration file:
```yaml
schema_type: mlcube_platform
schema_version: 0.1.0

platform:
  name: "docker"
  version: ">=18.01"
container:
  command: docker
  run_args: >-
    --rm  --gpus=all --net=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1
    --privileged=true --security-opt seccomp=unconfined -v /dev/shm:/dev/shm
  image: mlcommons/train_ssd:0.0.1

```

 Clone and checkout feature branch.
```bash
git clone https://github.com/sergey-serebryakov/mlbox.git
cd ./mlbox && git checkout feature/docker-args
```

Create python virtual environment.
```bash
virtualenv -p python3 ./env && source ./env/bin/activate
pip3 install -r ./mlcube/requirements.txt
pip3 install -r ./runners/mlcube_docker/requirements.txt
```

Configure MLCube host environment.
```bash
export PYTHONPATH=$(pwd)/mlcube:$(pwd)/runners/mlcube_docker
alias mlcube_docker="python -m mlcube_docker"
```

Clone example [MLCube](https://github.com/sergey-serebryakov/mlcube_train_ssd) that runs MLCommons SSD reference benchmarks. Checkout [feature/docker-args](https://github.com/sergey-serebryakov/mlcube_train_ssd/tree/feature/docker_args) branch.

Look at [docker](https://github.com/sergey-serebryakov/mlcube_train_ssd/blob/feature/docker_args/platforms/docker.yaml)/[podman](https://github.com/sergey-serebryakov/mlcube_train_ssd/blob/feature/docker_args/platforms/podman.yaml) platform configuration files. If you have already ran this MLCube, just replace docker platform configuration - everything else is the same. Then, configure and run (read the [readme](https://github.com/sergey-serebryakov/mlcube_train_ssd/tree/feature/docker_args) file before that contains some details about storage requirements - this benchmark uses COCO 2017 dataset):
```bash
mlcube_docker configure --mlcube=. --platform=platforms/docker.yaml
mlcube_docker run --mlcube=. --platform=platforms/docker.yaml --task=run/download.yaml
mlcube_docker run --mlcube=. --platform=platforms/podman.yaml --task=run/train.yaml
```


