### PR TITLE
Implementing MLCube CLI.

### DIFF
--- a/mlcube/mlcube/common/mlcube_metadata.py
+++ b/mlcube/mlcube/common/mlcube_metadata.py
@@ -1,6 +1,10 @@
 import os
+import textwrap
+
+import yaml
+from pathlib import Path
 from mlspeclib import MLObject
-from typing import (Any, Optional, Tuple)
+from typing import (Any, Optional)
 
 
 class MLCubeInvoke(object):
@@ -77,3 +81,120 @@ class MLCube(object):
     def __str__(self) -> str:
         return f"MLCube(root={self.root}, name={self.name}, version={self.version}, task={self.task}, "\
                f"invoke={self.invoke}, platform={self.platform})"
+
+
+class MLCubeFS(object):
+    def __init__(self, path: Optional[str]) -> None:
+        # All paths are absolute.
+        self.root = Path(path or Path.cwd()).absolute()
+        if self.root.is_file():
+            self.root = self.root.parent
+        self.mlcube_file = self.root / 'mlcube.yaml'
+        self.compact_mlcube_file = self.root / '.mlcube.yaml'
+        self.platforms = list((self.root / 'platforms').rglob('*.yaml'))
+        self.tasks = list((self.root / 'tasks').rglob('*.yaml'))
+        self.runs = list((self.root / 'run').rglob('*.yaml'))
+
+    @property
+    def num_platforms(self) -> int:
+        return len(self.platforms)
+
+    @property
+    def num_tasks(self) -> int:
+        return len(self.tasks)
+
+    @property
+    def num_runs(self) -> int:
+        return len(self.runs)
+
+    def summary(self):
+        print("------------------- MLCubeFS -------------------")
+        print(f"root = {self.root}")
+        if self.mlcube_file.exists():
+            print(f"mlcube file = {self.mlcube_file}")
+        if self.compact_mlcube_file.exists():
+            print(f"compact mlcube file = {self.compact_mlcube_file}")
+        print(f"platforms = {self.platforms}")
+        print(f"tasks = {self.tasks}")
+        print(f"runs = {self.runs}")
+
+    def get_platform_path(self, platform: Optional[str]) -> Path:
+        if platform is None:
+            if self.num_platforms != 1:
+                raise RuntimeError(f"When platform is not specified, number of MLCube platforms must be one. "
+                                   f"Platforms = {self.platforms}")
+            return self.platforms[0]
+        if not platform.endswith('.yaml'):
+            platform = self.root / 'platforms' / f'{platform}.yaml'
+        platform_path = Path(platform).absolute()
+        if not platform_path.exists():
+            raise RuntimeError(f"Platform does not exist: {platform_path}")
+        return platform_path
+
+    def get_task_instance_path(self, task_instance: Optional[str]) -> Path:
+        if task_instance is None:
+            if self.num_runs != 1:
+                raise RuntimeError(f"When task instance is not specified, number of MLCube task instances must be one. "
+                                   f"Task instances = {self.runs}")
+            return self.runs[0]
+        if not task_instance.endswith('.yaml'):
+            task_instance = self.root / 'run' / f'{task_instance}.yaml'
+        task_instance_path = Path(task_instance).absolute()
+        if not task_instance_path.exists():
+            raise RuntimeError(f"Task instance does not exist: {task_instance_path}")
+        return task_instance_path
+
+    @staticmethod
+    def get_platform_runner(path: Path) -> str:
+        platform: dict = yaml.safe_load(open(path, 'r'))
+        runner = platform.get('platform', {}).get('name', None)
+        if runner is None:
+            raise RuntimeError(f"Unsupported platform: {platform}")
+        if runner in ('docker', 'podman'):
+            return 'mlcube_docker'
+        if runner in ('singularity', ):
+            return 'mlcube_singularity'
+        raise RuntimeError(f"Unsupported runner: {runner}")
+
+    def describe(self) -> None:
+        mlcube: MLCube = MLCube(path=self.root)
+        print(f"MLCube")
+        print(f"  Path = {mlcube.root}")
+        print(f"  Name = {mlcube.name}:{mlcube.version}")
+
+        # -------------------------------------
+        print(f"  Platforms:")
+        for platform in self.platforms:
+            platform: dict = yaml.safe_load(open(platform, 'r'))
+            if 'platform' in platform:
+                details = ""
+                if 'container' in platform:
+                    details = f", container = {platform['container']}"
+                print(f"    Platform = {platform['platform']}{details}")
+
+        # -------------------------------------
+        print(f"  Tasks:")
+
+        def _print(d: dict) -> None:
+            text = textwrap.fill(f"{d['name']} ({d['type']}): {d['description']}", width=120, initial_indent=' ' * 8,
+                                 subsequent_indent=' ' * 12)
+            print(text)
+
+        for task in self.tasks:
+            print(f"    Task = {task.name[0:-5]}")
+            task = yaml.safe_load(open(task, 'r'))
+            print(f"      Inputs:")
+            for input_ in task.get('inputs', []):
+                _print(input_)
+            print(f"      Outputs:")
+            for output in task.get('outputs', []):
+                _print(output)
+
+        # -------------------------------------
+        platforms = '|'.join([platform.name[:-5] for platform in self.platforms])
+        print(f"Run this MLCube:")
+        print("  Configure MLCube:")
+        print(f"    mlcube configure --mlcube={self.root} --platform={platforms}")
+        print("  Run MLCube tasks:")
+        for task in self.tasks:
+            print(f"    mlcube run --mlcube={self.root} --task={task.name[0:-5]} --platform={platforms}")

--- a/mlcube/mlcube/tests/test_mlcommons_box_cli.py
+++ b/mlcube/mlcube/tests/test_mlcommons_box_cli.py
@@ -9,4 +9,4 @@ def test_mlcube():
     print(response.output)
     assert 'Usage: mlcube [OPTIONS] COMMAND [ARGS]...' in response.output
     assert 'MLCube 📦 is a packaging tool for ML models' in response.output
-    assert 'verify  Verify MLCube metadata' in response.output
+    assert 'Verify MLCube metadata' in response.output


### PR DESCRIPTION
This commit enables running MLCube on different platforms using mlcube CLI - a single entry point for all MLCube runners. The following is supported:
- `mlcube pull --mlcube=URL --branch=NAME`: Pull MLCube from some remote location. GitHub is the only supported protocol.
- `mlcube verify --mlcube=PATH`: Verify MLCube metadata.
- `mlcube describe --mlcube=PATH`: Describe this MLCube.
- `mlcube configure --mlcube=PATH --platform=PLATFORM`: Configure environment for MLCube ML workload.
- `mlcube run --mlcube=PATH --platform=PLATFORM --task=TASK`: Run MLCube ML workload.

Supported MLCube runners: `docker`, `podman` and `singluarity`.
Unsupported MLCube runners: `SSH`, `GCP` and `K8S`.

### Example

Get MLCube - MLCommons SSD Training Reference Benchmark:
```shell
mlcube pull --mlcube=https://github.com/sergey-serebryakov/mlcube_train_ssd --branch=feature/docker_args
cd ./mlcube_train_ssd
```

See what's inside:
```shell
mlcube describe

MLCube
  Path = /tmp/tttt/mlcube_train_ssd
  Name = mlcommons_training_ssd:0.1.0
  Platforms:
    Platform = {'name': 'docker', 'version': '>=18.01'}, container = {'command': 'docker', 'run_args': '--rm  --gpus=all --net=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 --privileged=true --security-opt seccomp=unconfined -v /dev/shm:/dev/shm', 'image': 'mlcommons/train_ssd:0.0.1'}
    Platform = {'name': 'podman', 'version': '>=1.6.4'}, container = {'command': 'docker', 'run_args': '--rm  --net=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 -e NVIDIA_VISABLE_DEVICES=ALL --privileged=true --security-opt seccomp=unconfined -v /dev/shm:/dev/shm', 'image': 'mlcommons/train_ssd:0.0.1'}
  Tasks:
    Task = train
      Inputs:
        data_dir (directory): See download::data_dir.
        parameters_file (file): File with input parameters, such as number of epochs.
      Outputs:
    Task = download
      Inputs:
      Outputs:
        cache_dir (directory): Cache directory for compressed datasets and annotations (COCO 2017). Will contain the
            following files: `train2017.zip`, `val2017.zip` and `annotations_trainval2017.zip`. Total size is ~ 20G. If
            these files are not present, they will be downloaded here.
        data_dir (directory): Directory for uncompressed datasets. Will contain the following subdirectories:
            `train2017`, `val2017` and `annotations`. Total size is ~ 20G. This is basically the content of archives in
            **cache_dir**.
Run this MLCube:
  Configure MLCube:
    mlcube configure --mlcube=/tmp/tttt/mlcube_train_ssd --platform=docker|podman
  Run MLCube tasks:
    mlcube run --mlcube=/tmp/tttt/mlcube_train_ssd --task=train --platform=docker|podman
    mlcube run --mlcube=/tmp/tttt/mlcube_train_ssd --task=download --platform=docker|podman
```

Configure MLCube (optional):
```shell
mlcube configure --platform=docker
```

Download data (40 GB of available disk space is required in MLCube's workspace):
```shell
mlcube run --task=download --platform=docker
```

Run training benchmark:
```shell
mlcube run --task=train --platform=docker
```