### PR TITLE
Compact MLCubes

### DIFF
--- a/mlcube/mlcube/common/mlcube_metadata.py
+++ b/mlcube/mlcube/common/mlcube_metadata.py
@@ -1,6 +1,10 @@
 import os
+import textwrap
+
+import yaml
+from pathlib import Path
 from mlspeclib import MLObject
-from typing import (Any, Optional, Tuple)
+from typing import (Any, Optional)
 
 
 class MLCubeInvoke(object):
@@ -77,3 +81,120 @@ class MLCube(object):
     def __str__(self) -> str:
         return f"MLCube(root={self.root}, name={self.name}, version={self.version}, task={self.task}, "\
                f"invoke={self.invoke}, platform={self.platform})"
+
+
+class MLCubeFS(object):
+    def __init__(self, path: Optional[str]) -> None:
+        # All paths are absolute.
+        self.root = Path(path or Path.cwd()).absolute()
+        if self.root.is_file():
+            self.root = self.root.parent
+        self.mlcube_file = self.root / 'mlcube.yaml'
+        self.compact_mlcube_file = self.root / '.mlcube.yaml'
+        self.platforms = list((self.root / 'platforms').rglob('*.yaml'))
+        self.tasks = list((self.root / 'tasks').rglob('*.yaml'))
+        self.runs = list((self.root / 'run').rglob('*.yaml'))
+
+    @property
+    def num_platforms(self) -> int:
+        return len(self.platforms)
+
+    @property
+    def num_tasks(self) -> int:
+        return len(self.tasks)
+
+    @property
+    def num_runs(self) -> int:
+        return len(self.runs)
+
+    def summary(self):
+        print("------------------- MLCubeFS -------------------")
+        print(f"root = {self.root}")
+        if self.mlcube_file.exists():
+            print(f"mlcube file = {self.mlcube_file}")
+        if self.compact_mlcube_file.exists():
+            print(f"compact mlcube file = {self.compact_mlcube_file}")
+        print(f"platforms = {self.platforms}")
+        print(f"tasks = {self.tasks}")
+        print(f"runs = {self.runs}")
+
+    def get_platform_path(self, platform: Optional[str]) -> Path:
+        if platform is None:
+            if self.num_platforms != 1:
+                raise RuntimeError(f"When platform is not specified, number of MLCube platforms must be one. "
+                                   f"Platforms = {self.platforms}")
+            return self.platforms[0]
+        if not platform.endswith('.yaml'):
+            platform = self.root / 'platforms' / f'{platform}.yaml'
+        platform_path = Path(platform).absolute()
+        if not platform_path.exists():
+            raise RuntimeError(f"Platform does not exist: {platform_path}")
+        return platform_path
+
+    def get_task_instance_path(self, task_instance: Optional[str]) -> Path:
+        if task_instance is None:
+            if self.num_runs != 1:
+                raise RuntimeError(f"When task instance is not specified, number of MLCube task instances must be one. "
+                                   f"Task instances = {self.runs}")
+            return self.runs[0]
+        if not task_instance.endswith('.yaml'):
+            task_instance = self.root / 'run' / f'{task_instance}.yaml'
+        task_instance_path = Path(task_instance).absolute()
+        if not task_instance_path.exists():
+            raise RuntimeError(f"Task instance does not exist: {task_instance_path}")
+        return task_instance_path
+
+    @staticmethod
+    def get_platform_runner(path: Path) -> str:
+        platform: dict = yaml.safe_load(open(path, 'r'))
+        runner = platform.get('platform', {}).get('name', None)
+        if runner is None:
+            raise RuntimeError(f"Unsupported platform: {platform}")
+        if runner in ('docker', 'podman'):
+            return 'mlcube_docker'
+        if runner in ('singularity', ):
+            return 'mlcube_singularity'
+        raise RuntimeError(f"Unsupported runner: {runner}")
+
+    def describe(self) -> None:
+        mlcube: MLCube = MLCube(path=self.root)
+        print(f"MLCube")
+        print(f"  Path = {mlcube.root}")
+        print(f"  Name = {mlcube.name}:{mlcube.version}")
+
+        # -------------------------------------
+        print(f"  Platforms:")
+        for platform in self.platforms:
+            platform: dict = yaml.safe_load(open(platform, 'r'))
+            if 'platform' in platform:
+                details = ""
+                if 'container' in platform:
+                    details = f", container = {platform['container']}"
+                print(f"    Platform = {platform['platform']}{details}")
+
+        # -------------------------------------
+        print(f"  Tasks:")
+
+        def _print(d: dict) -> None:
+            text = textwrap.fill(f"{d['name']} ({d['type']}): {d['description']}", width=120, initial_indent=' ' * 8,
+                                 subsequent_indent=' ' * 12)
+            print(text)
+
+        for task in self.tasks:
+            print(f"    Task = {task.name[0:-5]}")
+            task = yaml.safe_load(open(task, 'r'))
+            print(f"      Inputs:")
+            for input_ in task.get('inputs', []):
+                _print(input_)
+            print(f"      Outputs:")
+            for output in task.get('outputs', []):
+                _print(output)
+
+        # -------------------------------------
+        platforms = '|'.join([platform.name[:-5] for platform in self.platforms])
+        print(f"Run this MLCube:")
+        print("  Configure MLCube:")
+        print(f"    mlcube configure --mlcube={self.root} --platform={platforms}")
+        print("  Run MLCube tasks:")
+        for task in self.tasks:
+            print(f"    mlcube run --mlcube={self.root} --task={task.name[0:-5]} --platform={platforms}")

--- a/mlcube/mlcube/main.py
+++ b/mlcube/mlcube/main.py
@@ -6,7 +6,7 @@ from halo import Halo
 from pathlib import Path
 from typing import Optional
 from mlcube.check import check_root_dir
-from mlcube.common.mlcube_metadata import MLCubeFS
+from mlcube.common.mlcube_metadata import (MLCubeFS, CompactMLCube)
 
 
 logger = logging.getLogger(__name__)
@@ -20,11 +20,12 @@ def cli(log_level: str):
 
 
 @cli.command(name='verify', help='Verify MLCube metadata.')
-@click.option('--mlcube', required=True, type=str, help='MLCube path.')
+@click.option('--mlcube', required=False, type=str, help='MLCube path.')
 @Halo(text="", spinner="dots")
-def verify(mlcube: str):
+def verify(mlcube: Optional[str]) -> None:
     logging.info("Starting mlcube metadata verification")
-    metadata, verify_err = check_root_dir(Path(mlcube).resolve().as_posix())
+    mlcube_path = CompactMLCube(mlcube).unpack().mlcube_fs.root
+    metadata, verify_err = check_root_dir(mlcube_path)
     if verify_err:
         logging.error(f"Error verifying mlcube metadata: {verify_err}")
         logging.error(f"mlcube verification - FAILED!")
@@ -46,14 +47,14 @@ def pull(mlcube: str, branch: Optional[str]) -> None:
 @cli.command(name='describe', help='Describe this MLCube.')
 @click.option('--mlcube', required=False, type=str, help='MLCube location.')
 def describe(mlcube: Optional[str]) -> None:
-    MLCubeFS(mlcube).describe()
+    CompactMLCube(mlcube).unpack().mlcube_fs.describe()
 
 
 @cli.command(name='configure', help='Configure environment for MLCube ML workload.')
 @click.option('--mlcube', required=False, type=str, help='Path to MLCube directory.')
 @click.option('--platform', required=False, type=str, help='Path to MLCube Platform definition file.')
 def configure(mlcube: Optional[str], platform: Optional[str]):
-    mlcube_fs = MLCubeFS(mlcube)
+    mlcube_fs = CompactMLCube(mlcube).unpack().mlcube_fs
     platform_path = mlcube_fs.get_platform_path(platform)
     runner = mlcube_fs.get_platform_runner(platform_path)
     os.system(f"{runner} configure --mlcube={mlcube_fs.root} --platform={platform_path}")
@@ -64,7 +65,7 @@ def configure(mlcube: Optional[str], platform: Optional[str]):
 @click.option('--platform', required=False, type=str, help='Path to MLCube Platform definition file.')
 @click.option('--task', required=False, type=str, help='Path to MLCube Task definition file.')
 def run(mlcube: Optional[str], platform: Optional[str], task: Optional[str]):
-    mlcube_fs = MLCubeFS(mlcube)
+    mlcube_fs = CompactMLCube(mlcube).unpack().mlcube_fs
     platform_path = mlcube_fs.get_platform_path(platform)
     task_path = mlcube_fs.get_task_instance_path(task)
     runner = mlcube_fs.get_platform_runner(platform_path)

--- a/mlcube/mlcube/tests/test_mlcommons_box_cli.py
+++ b/mlcube/mlcube/tests/test_mlcommons_box_cli.py
@@ -9,4 +9,4 @@ def test_mlcube():
     print(response.output)
     assert 'Usage: mlcube [OPTIONS] COMMAND [ARGS]...' in response.output
     assert 'MLCube 📦 is a packaging tool for ML models' in response.output
-    assert 'verify  Verify MLCube metadata' in response.output
+    assert 'Verify MLCube metadata' in response.output


### PR DESCRIPTION
This PR depends on #180 (Implementing MLCube CLI).

Standard file system-based MLCube requires presence of several files, such as `mlcube.yaml`, task and task instance configuration files located in `tasks` and `run` directories. Compact MLCube requires the presence of `.mlcube.yaml` file that is "unpacked" on every MLCube invocation (describe/run/configure/...). 

Example "compact" MLCube is located [here](https://github.com/sergey-serebryakov/mlcube_train_ssd). In particular, the presence of the [.mlcube.yaml](https://github.com/sergey-serebryakov/mlcube_train_ssd/blob/master/.mlcube.yaml) file in the root directory makes this MLCube compact.

### Example

Get MLCube - MLCommons SSD Training Reference Benchmark:
```shell
mlcube pull --mlcube=https://github.com/sergey-serebryakov/mlcube_train_ssd
cd ./mlcube_train_ssd
```

See what's inside:
```shell
mlcube describe
```

Configure MLCube (optional):
```shell
mlcube configure --platform=docker
```

Download data (40 GB of available disk space is required in MLCube's workspace):
```shell
mlcube run --task=download --platform=docker
```

Run training benchmark:
```shell
mlcube run --task=train --platform=docker
```