### PR TITLE
Bug fix for using `sudo` while checking that MLCube docker container exists.

### DIFF
--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -36,7 +36,8 @@ class DockerRun(object):
         Returns:
             True if image exists, else false.
         """
-        return self._run_or_die(f"docker inspect --type=image {image_name} > /dev/null 2>&1", die_on_error=False) == 0
+        cmd: str = DockerRun.get_string_value(self.mlcube.platform.container.command, "docker")
+        return self._run_or_die(f"{cmd} inspect --type=image {image_name} > /dev/null 2>&1", die_on_error=False) == 0
 
     def configure(self):
         """Build Docker Image on a current host."""


### PR DESCRIPTION
When users need to use sudo with docker (i.e. `sudo docker`), they can specify it in a docker platform file (`command: sudo docker`). This command should be used for all docker-related operations, including checking if container exists, building and running containers. In current version, container presence check was done using hard-coded `docker` command. This commit fixes that.