### PR TITLE
Support to run docker-based MLCubes with Singularity runner.

### DIFF
--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,2 +1,3 @@
 click==7.1.2
 mlcube==0.0.4
+spython==0.2.1


### PR DESCRIPTION
This commit introduces a new MLCube feature that enables MLCube Singularity runner to run docker-based MLCubes. Following conditions must be met:
- MLCube is a docker-based MLCube with docker image hosted on docker hub. Not tested, but probably current implementation should work with private docker registries too.

**Implementation details**.

MLCube singularity runner normally uses information in `singularity` section in MLCube configuration file. If it is not present, or empty, singularity runner checks if `docker` section exists. If it exists, it creates the singularity runner configuration on the fly:
```yaml
image=''.join(c for c in d_cfg['image'] if c.isalnum()) + '.sif'
build_file='docker://' + d_cfg['image']
```
where `d_cfg` is the docker configuration section.

Singularity runtime supports multiple sources for image [build process](https://sylabs.io/guides/3.0/user-guide/build_a_container.html): `library://`, `docker://`, `shub://` etc. The update in this commit basically checks what the `build_file` parameter looks like. If it starts with `docker://`, use the `build_file` as source as is, else, treat this as a file name and use previously existing logic.

Tested with [MatMul example](https://github.com/mlcommons/mlcube_examples/tree/master/matmul):
```
mlcube --log-level info run --mlcube=. --task=matmul --platform=singularity
```