### PR TITLE
Improving user experience of MLCube's run command when tasks are not specified on a command line.

### DIFF
--- a/mlcube/mlcube/__main__.py
+++ b/mlcube/mlcube/__main__.py
@@ -95,7 +95,7 @@ platform_option = click.option(
     help="Platform to run MLCube, default is 'docker' (that also supports podman)."
 )
 task_option = click.option(
-    '--task', required=False, type=str, default='main',
+    '--task', required=False, type=str, default=None,
     help="MLCube task name(s) to run, default is `main`. This parameter can take a list value, in which case task names"
          "are separated with ','."
 )
@@ -170,8 +170,26 @@ def run(ctx: click.core.Context, mlcube: t.Text, platform: t.Text, task: t.Text,
         workspace: Workspace path to use. If not specified, default workspace inside MLCube directory is used.
     """
     runner_cls, mlcube_config = _parse_cli_args(ctx, mlcube, platform, workspace, resolve=True)
-    tasks: t.List[str] = CliParser.parse_list_arg(task, default='main')
+    mlcube_tasks: t.List[str] = list((mlcube_config.get('tasks', None) or {}).keys())  # Tasks in this MLCube.
+    tasks: t.List[str] = CliParser.parse_list_arg(task, default=None)                  # Requested tasks.
+
+    if len(tasks) == 0:
+        logger.warning("Missing required task name (--task=COMMA_SEPARATED_LIST_OF_TASK_NAMES).")
+        if len(mlcube_tasks) != 1:
+            logger.error("Task name could not be automatically resolved (supported tasks = %s).", str(mlcube_tasks))
+            exit(1)
+        logger.info("Task name has been automatically resolved to %s (supported tasks = %s).",
+                    mlcube_tasks[0], str(mlcube_tasks))
+        tasks = mlcube_tasks
+
+    unknown_tasks: t.List[str] = [name for name in tasks if name not in mlcube_tasks]
+    if len(unknown_tasks) > 0:
+        logger.error("Unknown tasks have been requested: supported tasks = %s, requested tasks = %s, "
+                     "unknown tasks = %s.", str(mlcube_tasks), str(tasks), str(unknown_tasks))
+        exit(1)
+
     for task in tasks:
+        logger.info("Task = %s", task)
         docker_runner = runner_cls(mlcube_config, task=task)
         docker_runner.run()
 


### PR DESCRIPTION
## Previous behavior: run command
When task parameter (--task) is not present on a command line, it is automatically set to `main`. No additional checks are performed.

## New behavior: run command
- Default task name is None (not specified).
- When task is None
  - and MLCube supports only one task, run it.
  - else report this error and exist.
- Check if all requested tasks are supported.
  - If not, report this error and exist.