### PR TITLE
Update PyYAML package version

### DIFF
--- a/mlcube/requirements.txt
+++ b/mlcube/requirements.txt
@@ -9,5 +9,5 @@ halo==0.0.30
 coloredlogs==14.0
 cookiecutter==1.7.2
 docker==4.3.1
-pyyaml==5.3.1
+PyYAML>=5.4
 omegaconf==2.1.0


### PR DESCRIPTION
Update PyYAML package version to fix dependabot alert that is currently blocking Medperf PRs.

[Alert](https://github.com/mlcommons/medperf/security/dependabot?q=is%3Aopen+package%3APyYAML+manifest%3Acli%2Fmedperf%2Frequirements.txt+has%3Apatch)