### PR TITLE
Refactoring `Shell.run` method.

### DIFF
--- a/mlcube/mlcube/__main__.py
+++ b/mlcube/mlcube/__main__.py
@@ -301,7 +301,7 @@ def create() -> None:
         from cookiecutter.main import cookiecutter
         proj_dir: t.Text = cookiecutter(mlcube_cookiecutter_url)
         if proj_dir and os.path.isfile(os.path.join(proj_dir, 'mlcube.yaml')):
-            Shell.run('mlcube', 'describe', '--mlcube', proj_dir)
+            Shell.run(['mlcube', 'describe', '--mlcube', proj_dir], on_error='die')
     except ImportError:
         print("Cookiecutter library not found.")
         print("\tInstall it: pip install cookiecutter")

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -95,7 +95,7 @@ class DockerRun(Runner):
         if build_strategy == Config.BuildStrategy.PULL or not build_recipe_exists:
             logger.info("Will pull image (%s) because (build_strategy=%s, build_recipe_exists=%r)",
                         image, build_strategy, build_recipe_exists)
-            Shell.run(docker, 'pull', image)
+            Shell.run([docker, 'pull', image], on_error='raise')
             if build_recipe_exists:
                 logger.warning("Docker recipe exists (%s), but your build strategy is '%s', and so the image has been "
                                "pulled, not built. Make sure your image is up-to-data with your source code.",
@@ -104,7 +104,7 @@ class DockerRun(Runner):
             logger.info("Will build image (%s) because (build_strategy=%s, build_recipe_exists=%r)",
                         image, build_strategy, build_recipe_exists)
             build_args: t.Text = self.mlcube.runner.build_args
-            Shell.run(docker, 'build', build_args, '-t', image, '-f', recipe, context)
+            Shell.run([docker, 'build', build_args, '-t', image, '-f', recipe, context], on_error='raise')
 
     def run(self) -> None:
         """ Run a cube. """
@@ -137,4 +137,4 @@ class DockerRun(Runner):
         num_gpus: int = self.mlcube.platform.get('accelerator_count', None) or 0
         run_args: t.Text = self.mlcube.runner.cpu_args if num_gpus == 0 else self.mlcube.runner.gpu_args
 
-        Shell.run(docker, 'run', run_args, env_args, volumes, image, ' '.join(task_args))
+        Shell.run([docker, 'run', run_args, env_args, volumes, image, ' '.join(task_args)], on_error='raise')

--- a/runners/mlcube_gcp/mlcube_gcp/gcp_run.py
+++ b/runners/mlcube_gcp/mlcube_gcp/gcp_run.py
@@ -111,8 +111,12 @@ class GCPRun(Runner):
         print(instance)
 
         # Should be as simple as invoking SSH configure.
-        Shell.run('mlcube', 'configure', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}')
+        Shell.run(['mlcube', 'configure', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}'],
+                  on_error='raise')
 
     def run(self) -> None:
         gcp: DictConfig = self.mlcube.runner
-        Shell.run('mlcube', 'run', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}', f'--task={self.task}')
+        Shell.run(
+            ['mlcube', 'run', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}', f'--task={self.task}'],
+            on_error='raise'
+        )

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -64,8 +64,8 @@ class SingularityRun(Runner):
         if not os.path.exists(recipe_file):
             raise IOError(f"Singularity recipe not found: {recipe_file}")
         Shell.run(
-            'cd', recipe_path, ';',
-            s_cfg.singularity, 'build', s_cfg.build_args, image_uri, s_cfg.build_file
+            ['cd', recipe_path, ';', s_cfg.singularity, 'build', s_cfg.build_args, image_uri, s_cfg.build_file],
+            on_error='raise'
         )
 
     def run(self) -> None:
@@ -82,4 +82,4 @@ class SingularityRun(Runner):
 
         volumes = Shell.to_cli_args(mounts, sep=':', parent_arg='--bind')
 
-        Shell.run(self.mlcube.runner.singularity, 'run', volumes, image_uri, ' '.join(task_args))
+        Shell.run([self.mlcube.runner.singularity, 'run', volumes, image_uri, ' '.join(task_args)], on_error='raise')

--- a/tests/mlcube/test_shell.py
+++ b/tests/mlcube/test_shell.py
@@ -6,7 +6,7 @@ class TestShell(TestCase):
     def test_run_01(self) -> None:
         for cmd in (['python --version'], ['python', '--version']):
             for die_on_error in (True, False):
-                exit_code = Shell.run(*cmd, die_on_error=die_on_error)
+                exit_code = Shell.run(cmd, on_error='die')
                 self.assertEqual(exit_code, 0, f"cmd = {cmd}, die_on_error = {die_on_error}")
 
     def test_run_02(self) -> None:
@@ -16,9 +16,9 @@ class TestShell(TestCase):
             '8389dfb48c6f4a1aaa16bdda76c1fb11'
         ]
         for cmd in cmds:
-            exit_code = Shell.run(cmd, die_on_error=False)
+            exit_code = Shell.run(cmd, on_error='die')
             self.assertGreater(exit_code, 0, f"cmd = {cmd}")
 
     def test_run_03(self) -> None:
         with self.assertRaises(RuntimeError):
-            _ = Shell.run('python -c "print(message)"', die_on_error=True)
+            _ = Shell.run('python -c "print(message)"', on_error='die')


### PR DESCRIPTION
1. Command to run: moving from list of args to a single argument that can be one of - string, iterable (tuple, list).
2. The `die_on_error: bool` argument was renamed to `on_error: t.Optional[str]`. It defines an action to perform when non-zero exit status is returned. Possible values - None (do nothing, just return the code), `raise` (raise an exception) and `die` (call sys.exit with returned status code).