### PR TITLE
Convert local tarball docker images to singularity

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -75,7 +75,7 @@ class Config(RunnerConfig):
 
             build_file = 'docker://' + d_cfg['image']
             if 'tar_file' in d_cfg:
-                build_file = 'docker-archive://' + d_cfg['tar_file']
+                build_file = 'docker-archive:' + d_cfg['tar_file']
             s_cfg = OmegaConf.create(dict(
                 image=''.join(c for c in d_cfg['image'] if c.isalnum()) + '.sif',
                 build_file=build_file,

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -73,9 +73,12 @@ class Config(RunnerConfig):
             except:
                 logger.warning("SingularityRun can't get singularity version (do you have singularity installed?).")
 
+            build_file = 'docker://' + d_cfg['image']
+            if 'tar_file' in d_cfg:
+                build_file = 'docker-archive://' + d_cfg['tar_file']
             s_cfg = OmegaConf.create(dict(
                 image=''.join(c for c in d_cfg['image'] if c.isalnum()) + '.sif',
-                build_file='docker://' + d_cfg['image'],
+                build_file=build_file,
                 build_args=build_args,
                 singularity='singularity'
             ))
@@ -133,7 +136,7 @@ class SingularityRun(Runner):
 
         build_path = Path(self.mlcube.runtime.root)     # Let's assume that build context is the root MLCube directory
         recipe: str = s_cfg.build_file                  # This is the recipe file, or docker image.
-        if recipe.startswith('docker://'):
+        if recipe.startswith('docker://') or recipe.startswith('docker-archive://'):
             # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
             # URI beginning with docker:// to build from Docker Hub
             logger.info("SingularityRun building SIF from docker image (%s).", recipe)

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -136,7 +136,7 @@ class SingularityRun(Runner):
 
         build_path = Path(self.mlcube.runtime.root)     # Let's assume that build context is the root MLCube directory
         recipe: str = s_cfg.build_file                  # This is the recipe file, or docker image.
-        if recipe.startswith('docker://') or recipe.startswith('docker-archive://'):
+        if recipe.startswith('docker://') or recipe.startswith('docker-archive:'):
             # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
             # URI beginning with docker:// to build from Docker Hub
             logger.info("SingularityRun building SIF from docker image (%s).", recipe)

--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,2 +1,3 @@
 click==7.1.2
 mlcube==0.0.4
+spython==0.2.1


### PR DESCRIPTION
Install the latest version of the Singularity runner.

```bash
virtualenv -p python3 env && source ./env/bin/activate

git clone https://github.com/mlcommons/mlcube && cd ./mlcube

git fetch origin pull/241/head:feature/singularity_with_docker_images && git checkout feature/singularity_with_docker_images

pip install semver spython && pip install ./mlcube

pip install --no-deps --force-reinstall ./runners/mlcube_singularity
```

To convert a local Docker image, first find the Docker image ID:

```bash
docker images
#output:
#REPOSITORY        TAG       IMAGE ID        CREATED        SIZE
#my_image          latest    bf756fb1ae65    5 months ago   13.3kB
```

Then, create a tarball of the Docker image using the image ID:

```bash
docker save bf756fb1ae65 -o my_docker_image.tar 
```

Then, you must specify the path to the tarball file inside the **mlcube.yaml** file:

```yaml
docker:
  # Image name.
  image: my_user/my_image:0.0.1
  tar_file: path_to/my_docker_image.tar
```

After getting the **mlcube.yaml** done with the needed data from the Docker image you want to convert, you can convert the image while running any MLCube task using the following command:

```bash
mlcube run --mlcube=mlcube.yaml --task=my_task --platform=singularity
```