### PR TITLE
Add Singularity run arguments [WIP]

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -75,7 +75,7 @@ class Config(RunnerConfig):
 
             build_file = 'docker://' + d_cfg['image']
             if 'tar_file' in d_cfg:
-                build_file = 'docker-archive://' + d_cfg['tar_file']
+                build_file = 'docker-archive:' + d_cfg['tar_file']
             s_cfg = OmegaConf.create(dict(
                 image=''.join(c for c in d_cfg['image'] if c.isalnum()) + '.sif',
                 build_file=build_file,

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -27,6 +27,7 @@ class Config(RunnerConfig):
         'singularity': 'singularity',                      # Executable file for singularity runtime.
 
         'build_args': '--fakeroot',                        # Image build arguments.
+        'run_args': '',                                    # Image build arguments.
         # Sergey: there seems to be a better name for this parameter. Originally, the only source was a singularity
         # recipe (build file). Later, MLCube started to support other sources, such as docker images.
         'build_file': 'Singularity.recipe'                 # Source for the image build process.
@@ -166,7 +167,9 @@ class SingularityRun(Runner):
 
         volumes = Shell.to_cli_args(mounts, sep=':', parent_arg='--bind')
 
+        run_args = self.mlcube.runner.run_args
+
         Shell.run(
-            [self.mlcube.runner.singularity, 'run', volumes, str(image_file), ' '.join(task_args)],
+            [self.mlcube.runner.singularity, 'run', run_args, volumes, str(image_file), ' '.join(task_args)],
             on_error='raise'
         )

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -73,9 +73,12 @@ class Config(RunnerConfig):
             except:
                 logger.warning("SingularityRun can't get singularity version (do you have singularity installed?).")
 
+            build_file = 'docker://' + d_cfg['image']
+            if 'tar_file' in d_cfg:
+                build_file = 'docker-archive://' + d_cfg['tar_file']
             s_cfg = OmegaConf.create(dict(
                 image=''.join(c for c in d_cfg['image'] if c.isalnum()) + '.sif',
-                build_file='docker://' + d_cfg['image'],
+                build_file=build_file,
                 build_args=build_args,
                 singularity='singularity'
             ))
@@ -133,7 +136,7 @@ class SingularityRun(Runner):
 
         build_path = Path(self.mlcube.runtime.root)     # Let's assume that build context is the root MLCube directory
         recipe: str = s_cfg.build_file                  # This is the recipe file, or docker image.
-        if recipe.startswith('docker://'):
+        if recipe.startswith('docker://') or recipe.startswith('docker-archive://'):
             # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
             # URI beginning with docker:// to build from Docker Hub
             logger.info("SingularityRun building SIF from docker image (%s).", recipe)

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -136,7 +136,7 @@ class SingularityRun(Runner):
 
         build_path = Path(self.mlcube.runtime.root)     # Let's assume that build context is the root MLCube directory
         recipe: str = s_cfg.build_file                  # This is the recipe file, or docker image.
-        if recipe.startswith('docker://') or recipe.startswith('docker-archive://'):
+        if recipe.startswith('docker://') or recipe.startswith('docker-archive:'):
             # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
             # URI beginning with docker:// to build from Docker Hub
             logger.info("SingularityRun building SIF from docker image (%s).", recipe)

--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,2 +1,3 @@
 click==7.1.2
 mlcube==0.0.4
+spython==0.2.1


### PR DESCRIPTION
Add singularity feature to allow run arguments, these run arguments can now be defined in the mlcube.yaml file, example:

```yaml
singularity:
        run_args: "-C --writable-tmpfs --net --network=none --nv"
```