### PR TITLE
Support for MLCube CLI to return exit codes when executions fail.

### DIFF
--- a/mlcube/mlcube/tests/test_errors.py
+++ b/mlcube/mlcube/tests/test_errors.py
@@ -1,0 +1,40 @@
+import typing as t
+from unittest import TestCase
+from mlcube.errors import ExecutionError
+
+
+class TestErrors(TestCase):
+
+    def check_execution_error_state(self, err: ExecutionError, message: str, description: str, context: t.Dict) -> None:
+        self.assertEqual(err.message, message)
+        self.assertEqual(err.description, description)
+        self.assertDictEqual(err.context, context)
+
+        self.assertEqual(
+            err.describe(frmt='text'),
+            f"ERROR:\n\tmessage: {message}\n\tdescription: {description}\n\tcontext: {context}"
+        )
+
+    def test_execution_error_init_method(self) -> None:
+        self.check_execution_error_state(
+            ExecutionError("Brief error description.", "Long error description.", param_a='value_a', param_b=1.2),
+            "Brief error description.", "Long error description.", {'param_a': 'value_a', 'param_b': 1.2}
+        )
+
+    def test_execution_error_mlcube_configure_error_method(self) -> None:
+        self.check_execution_error_state(
+            ExecutionError.mlcube_configure_error(
+                "MLCube Reference Runner", "Long error description.", param_a='value_a', param_b=1.2
+            ),
+            "MLCube Reference Runner runner failed to configure MLCube.", "Long error description.",
+            {'param_a': 'value_a', 'param_b': 1.2}
+        )
+
+    def test_execution_error_mlcube_run_error_method(self) -> None:
+        self.check_execution_error_state(
+            ExecutionError.mlcube_run_error(
+                "MLCube Reference Runner", "Long error description.", param_a='value_a', param_b=1.2
+            ),
+            "MLCube Reference Runner runner failed to run MLCube.", "Long error description.",
+            {'param_a': 'value_a', 'param_b': 1.2}
+        )

--- a/runners/mlcube_gcp/mlcube_gcp/gcp_run.py
+++ b/runners/mlcube_gcp/mlcube_gcp/gcp_run.py
@@ -7,6 +7,7 @@ from mlcube.validate import Validate
 from mlcube_ssh.ssh_run import Shell
 from ssh_config.client import (SSHConfig, Host)
 from mlcube.runner import (RunnerConfig, Runner)
+from mlcube.errors import ExecutionError
 from mlcube_gcp.gcp_client.instance import Instance as GCPInstance, Status as GCPInstanceStatus
 from mlcube_gcp.gcp_client.service import Service
 
@@ -60,36 +61,67 @@ class GCPRun(Runner):
         gcp: DictConfig = self.mlcube.runner
 
         # Check that SSH is configured.
+        # TODO: (Sergey) why am I doing it here (copy-past bug)?
         ssh_config_file = os.path.join(Path.home(), '.ssh', 'mlcube')
         try:
             ssh_config = SSHConfig.load(ssh_config_file)
             gcp_host: Host = ssh_config.get(gcp.instance.name)
         except KeyError:
-            raise ValueError(f"SSH mlcube ({ssh_config_file}) does not provide connection "
-                             f"details for '{gcp.instance.name}'")
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                f"SSH configuration file ({ssh_config_file}) does not provide connection details for GCP instance "
+                f"(name={gcp.instance.name}). Most likely this error has occurred due to implementation error - "
+                "please, contact MLCube developers."
+            )
         # TODO: I can try to add this info on the fly assuming standard paths. Need to figure out the user name.
         if gcp_host.get('User', None) is None or gcp_host.get('IdentityFile', None) is None:
-            raise ValueError(f"SSH mlcube does not provide connection details for '{gcp.instance.name}'")
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                f"SSH configuration file ({ssh_config_file}) provides connection details for GCP instance "
+                f"(name={gcp.instance.name}), but these details do not include information about `User` "
+                "and/or `IdentifyFile`."
+            )
 
         # Connect to GCP
         logger.info("Connecting to GCP ...")
-        service = Service(project_id=gcp.gcp.project_id, zone=gcp.gcp.zone, credentials=gcp.gcp.credentials)
+        try:
+            service = Service(project_id=gcp.gcp.project_id, zone=gcp.gcp.zone, credentials=gcp.gcp.credentials)
+        except Exception as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                "The error most like is associated with either reading credentials, or connecting using google API ("
+                f"project_id={gcp.gcp.project_id}, zone={gcp.gcp.zone}, credentials={gcp.gcp.credentials}). See "
+                "context for more details.",
+                error=str(err),
+                gcp_info={'project_id': gcp.gcp.project_id, 'zone': gcp.gcp.zone, 'credentials': gcp.gcp.credentials}
+            )
 
         # Figure out if an instance needs to be created
-        instance = GCPInstance(service.get_instance(gcp.instance.name))
-        if instance.name is None:
-            print("Creating GCP instance ...")
-            service.wait_for_operation(
-                service.create_instance(name=gcp.instance.name, machine_type=gcp.instance.machine_type,
-                                        disk_size_gb=gcp.instance.disk_size_gb)
-            )
+        try:
             instance = GCPInstance(service.get_instance(gcp.instance.name))
+            if instance.name is None:
+                print("Creating GCP instance ...")
+                service.wait_for_operation(
+                    service.create_instance(name=gcp.instance.name, machine_type=gcp.instance.machine_type,
+                                            disk_size_gb=gcp.instance.disk_size_gb)
+                )
+                instance = GCPInstance(service.get_instance(gcp.instance.name))
 
-        # Check its running status
-        if instance.status != GCPInstanceStatus.RUNNING:
-            print("Starting GCP instance ...")
-            service.wait_for_operation(service.start_instance(instance.name))
-            instance = GCPInstance(service.get_instance(gcp.instance.name))
+            # Check its running status
+            if instance.status != GCPInstanceStatus.RUNNING:
+                print("Starting GCP instance ...")
+                service.wait_for_operation(service.start_instance(instance.name))
+                instance = GCPInstance(service.get_instance(gcp.instance.name))
+        except Exception as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                "Failed to create or connect to remote GCP instance. See context for more details.",
+                error=str(err),
+                gcp_instance_info={
+                    'name': gcp.instance.name, 'machine_type': gcp.instance.machine_type,
+                    'disk_size_gb': gcp.instance.disk_size_gb
+                }
+            )
 
         # Make sure SSH mlcube is up-to-date
         if gcp_host.get('HostName', None) != instance.public_ip:
@@ -100,23 +132,41 @@ class GCPRun(Runner):
             # TODO: clean '.ssh/known_hosts'.
 
         # Configure remote instance. This is specific for docker-based images now.
-        Shell.ssh(
-            gcp.instance.name,
-            'sudo snap install docker && sudo addgroup --system docker && sudo adduser ${USER} docker && '
-            'sudo snap disable docker && sudo snap enable docker && '
-            'sudo apt update && yes | sudo apt install python3-pip virtualenv && sudo apt clean'
-        )
+        try:
+            Shell.ssh(
+                gcp.instance.name,
+                'sudo snap install docker && sudo addgroup --system docker && sudo adduser ${USER} docker && '
+                'sudo snap disable docker && sudo snap enable docker && '
+                'sudo apt update && yes | sudo apt install python3-pip virtualenv && sudo apt clean'
+            )
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                "Failed to install system packages on a remote instance. See context for more details.",
+                error=str(err)
+            )
 
         # Remote GCP instance has been configured
         print(instance)
 
         # Should be as simple as invoking SSH configure.
-        Shell.run(['mlcube', 'configure', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}'],
-                  on_error='raise')
+        try:
+            Shell.run(f"mlcube configure --mlcube={self.mlcube.root} --platform={gcp.platform}")
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                f"Error occurred while running mlcube configure with GCP platform (platform={gcp.platform}). See "
+                "context for more details.",
+                error=str(err)
+            )
 
     def run(self) -> None:
         gcp: DictConfig = self.mlcube.runner
-        Shell.run(
-            ['mlcube', 'run', f'--mlcube={self.mlcube.root}', f'--platform={gcp.platform}', f'--task={self.task}'],
-            on_error='raise'
-        )
+        try:
+            Shell.run(f"mlcube run --mlcube={self.mlcube.root} --platform={gcp.platform} --task={self.task}")
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                f"Error occurred while running MLCube task (platform={gcp.platform}, task={self.task}).",
+                **err.context
+            )

--- a/runners/mlcube_k8s/mlcube_k8s/k8s_run.py
+++ b/runners/mlcube_k8s/mlcube_k8s/k8s_run.py
@@ -4,6 +4,7 @@ import kubernetes
 import time
 import typing as t
 from omegaconf import (DictConfig, OmegaConf)
+from mlcube.errors import ExecutionError
 from mlcube.runner import (RunnerConfig, Runner)
 from mlcube.validate import Validate
 
@@ -126,7 +127,6 @@ class KubernetesRun(Runner):
                 break
             time.sleep(10)
 
-
     def configure(self) -> None:
         ...
 
@@ -139,8 +139,9 @@ class KubernetesRun(Runner):
             mlcube_job_manifest = self.create_job_manifest()
             job = self.create_job(mlcube_job_manifest)
             self.wait_for_completion(job)
-        except urllib3.exceptions.HTTPError:
-            print(f"K8S runner failed to run MLCube. The actual error is printed below. "
-                  "Your MLCube k8s configuration was:")
-            print(OmegaConf.to_yaml(self.mlcube.runner, resolve=True))
-            raise
+        except Exception as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                "See context for more details.",
+                error=str(err)
+            )

--- a/runners/mlcube_kubeflow/mlcube_kubeflow/kubeflow_run.py
+++ b/runners/mlcube_kubeflow/mlcube_kubeflow/kubeflow_run.py
@@ -1,11 +1,11 @@
 import logging
-import urllib3
 import typing as t
 import kfp
 import kfp.compiler as compiler
 import kfp.dsl as dsl
 from datetime import datetime
 from omegaconf import (DictConfig, OmegaConf)
+from mlcube.errors import ExecutionError
 from mlcube.runner import (RunnerConfig, Runner)
 from mlcube.validate import Validate
 
@@ -94,8 +94,9 @@ class KubeflowRun(Runner):
         try:
             logging.info("Configuring MLCube to run in Kubeflow Pipelines...")
             _ = self.create_kf_pipeline()
-        except urllib3.exceptions.HTTPError:
-            print(f"K8S runner failed to run MLCube. The actual error is printed below. "
-                  "Your MLCube kubeflow configuration was:")
-            print(OmegaConf.to_yaml(self.mlcube.runner, resolve=True))
-            raise
+        except Exception as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                "See context for more details.",
+                error=str(err)
+            )

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from omegaconf import (DictConfig, OmegaConf)
 import semver
 from spython.utils.terminal import (get_singularity_version_info, check_install as check_singularity_installed)
+from mlcube.errors import (ConfigurationError, ExecutionError)
 from mlcube.shell import Shell
 from mlcube.runner import (Runner, RunnerConfig)
 
@@ -101,11 +102,12 @@ class SingularityRun(Runner):
     @staticmethod
     def check_install(singularity_exec: str = 'singularity') -> None:
         if not check_singularity_installed(software=singularity_exec):
-            msg = "SingularityRun check_install returned false ('singularity --version' failed to run). MLCube cannot "\
-                  "run singularity images unless this check passes. Singularity runner uses `check_install` function "\
-                  "from singularity-cli python library (https://github.com/singularityhub/singularity-cli)"
-            logger.error(msg)
-            raise RuntimeError(msg)
+            raise ExecutionError(
+                f"{SingularityRun.__name__} runner failed to configure or to run MLCube.",
+                "SingularityRun check_install returned false ('singularity --version' failed to run). MLCube cannot "
+                "run singularity images unless this check passes. Singularity runner uses `check_install` function "
+                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli)."
+            )
 
     def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: str) -> None:
         super().__init__(mlcube, task)
@@ -145,10 +147,16 @@ class SingularityRun(Runner):
             if not Path(build_path, recipe).exists():
                 raise IOError(f"SIF recipe file does not exist (path={build_path}, file={recipe})")
             logger.info("Building SIF from recipe file (path=%s, file=%s).", build_path, recipe)
-        Shell.run(
-            ['cd', str(build_path), ';', s_cfg.singularity, 'build', s_cfg.build_args, str(image_file), recipe],
-            on_error='raise'
-        )
+        try:
+            Shell.run([
+                'cd', str(build_path), ';', s_cfg.singularity, 'build', s_cfg.build_args, str(image_file), recipe
+            ])
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                "Error occurred while building SIF image. See context for more details.",
+                **err.context
+            )
 
     def run(self) -> None:
         """  """
@@ -159,14 +167,33 @@ class SingularityRun(Runner):
             SingularityRun.check_install()
 
         # Deal with user-provided workspace
-        Shell.sync_workspace(self.mlcube, self.task)
+        try:
+            Shell.sync_workspace(self.mlcube, self.task)
+        except Exception as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                "Error occurred while syncing MLCube workspace. See context for more details.",
+                error=str(err)
+            )
 
-        mounts, task_args = Shell.generate_mounts_and_args(self.mlcube, self.task)
-        logger.info(f"mounts={mounts}, task_args={task_args}")
+        try:
+            mounts, task_args = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            logger.info(f"mounts={mounts}, task_args={task_args}")
+        except ConfigurationError as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                "Error occurred while generating mount points for singularity run command. See context for more "
+                "details and check your MLCube configuration file.",
+                error=str(err)
+            )
 
         volumes = Shell.to_cli_args(mounts, sep=':', parent_arg='--bind')
 
-        Shell.run(
-            [self.mlcube.runner.singularity, 'run', volumes, str(image_file), ' '.join(task_args)],
-            on_error='raise'
-        )
+        try:
+            Shell.run([self.mlcube.runner.singularity, 'run', volumes, str(image_file), ' '.join(task_args)])
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                f"Error occurred while running MLCube task (task={self.task}). See context for more details.",
+                **err.context
+            )

--- a/tests/mlcube/test_shell.py
+++ b/tests/mlcube/test_shell.py
@@ -1,10 +1,12 @@
 from unittest import TestCase
+
+from mlcube.errors import ExecutionError
 from mlcube.shell import Shell
 
 
 class TestShell(TestCase):
     def test_run_01(self) -> None:
-        for cmd in (['python --version'], ['python', '--version']):
+        for cmd in ('python --version', ['python', '--version']):
             for die_on_error in (True, False):
                 exit_code = Shell.run(cmd, on_error='die')
                 self.assertEqual(exit_code, 0, f"cmd = {cmd}, die_on_error = {die_on_error}")
@@ -16,9 +18,9 @@ class TestShell(TestCase):
             '8389dfb48c6f4a1aaa16bdda76c1fb11'
         ]
         for cmd in cmds:
-            exit_code = Shell.run(cmd, on_error='die')
+            exit_code = Shell.run(cmd, on_error='ignore')
             self.assertGreater(exit_code, 0, f"cmd = {cmd}")
 
     def test_run_03(self) -> None:
-        with self.assertRaises(RuntimeError):
-            _ = Shell.run('python -c "print(message)"', on_error='die')
+        with self.assertRaises(ExecutionError):
+            _ = Shell.run('python -c "print(message)"', on_error='raise')


### PR DESCRIPTION
This commit enables MLCube command line interface (CLI) to return proper exit codes when MLCube execution fails. Two types of executions are supported - `configure` and `run`.
1. All MLCube runners raise `ExecutionError` exceptions.
2. MLCube runtime catches these exceptions, prints the information on a console and exits with specific exit codes. These codes:
   - 0: if execution was successful.
   - 1: when MLCube fails to execute configure/run actions for some internal reason, or when MLCube tasks return 1s.
   - >1: when MLCube tasks return non-zero exit codes.
   - <0: when MLCube tasks are terminated or stopped. In this case, absolute value of the exit codes equals to signal that caused MLCube task to terminate.