### PR TITLE
Fix Singularity runner Shell.run method

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -183,14 +183,17 @@ class SingularityRun(Runner):
                 "Building SIF from recipe file (path=%s, file=%s).", build_path, recipe
             )
         Shell.run(
-            "cd",
-            str(build_path),
-            ";",
-            s_cfg.singularity,
-            "build",
-            s_cfg.build_args,
-            str(image_file),
-            recipe
+            [
+                "cd",
+                str(build_path),
+                ";",
+                s_cfg.singularity,
+                "build",
+                s_cfg.build_args,
+                str(image_file),
+                recipe,
+            ],
+            on_error="raise",
         )
 
     def run(self) -> None:
@@ -210,10 +213,13 @@ class SingularityRun(Runner):
         volumes = Shell.to_cli_args(mounts, sep=":", parent_arg="--bind")
 
         Shell.run(
-            self.mlcube.runner.singularity,
-            "run",
-            self.mlcube.runner.run_args,
-            volumes,
-            str(image_file),
-            " ".join(task_args),
+            [
+                self.mlcube.runner.singularity,
+                "run",
+                self.mlcube.runner.run_args,
+                volumes,
+                str(image_file),
+                " ".join(task_args),
+            ],
+            on_error="raise",
         )


### PR DESCRIPTION
Fixed the way Shell.run method was called, now has the same structure as Docker runner:

```python
Shell.run([

              "cd",

              str(build_path),

              ";",

              s_cfg.singularity,

              "build",

              s_cfg.build_args,

              str(image_file),

              recipe

] , on_error="raise")
```