### PR TITLE
Fix Singularity shell execution: Added missing arguments

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -220,7 +220,7 @@ class SingularityRun(Runner):
 
         volumes = Shell.to_cli_args(mounts, sep=":", parent_arg="--bind")
         try:
-            Shell.run([self.mlcube.runner.singularity, 'run', volumes, str(image_file), ' '.join(task_args)])
+            Shell.run([self.mlcube.runner.singularity, 'run', self.mlcube.runner.run_args, volumes, str(image_file), ' '.join(task_args)])
         except ExecutionError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,


### PR DESCRIPTION
This PR contains the fix for this issue: [254](https://github.com/mlcommons/mlcube/issues/254)

The singularity runner was not passing the specified arguments that are part of the singularity command.