### PR TITLE
Unit tests for docker runner + improvements / bug-fixes.

### DIFF
--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -26,6 +26,16 @@ class Shell(object):
     """Helper functions to run commands."""
 
     @staticmethod
+    def null() -> str:
+        """Return /dev/null for Linux/Windows.
+
+        TODO: In powershell, $null works. Is below the correct implementation?
+        """
+        if os.name == 'nt':
+            return 'NUL'
+        return '/dev/null'
+
+    @staticmethod
     def parse_exec_status(status: int) -> t.Tuple[int, str]:
         """Parse execution status returned by `os.system` call.
 
@@ -100,7 +110,8 @@ class Shell(object):
             True if image exists, else false.
         """
         docker = docker or 'docker'
-        return Shell.run(f'{docker} inspect --type=image {image} > /dev/null 2>&1', on_error='ignore') == 0
+        cmd = f'{docker} inspect --type=image {image} > {Shell.null()}'
+        return Shell.run(cmd, on_error='ignore') == 0
 
     @staticmethod
     def ssh(connection_str: str, command: t.Optional[str], on_error: str = 'raise') -> int:

--- a/runners/mlcube_docker/mlcube_docker/tests/test_config.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_config.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from mlcube_docker.docker_run import Config
+from mlcube.errors import IllegalParameterValueError
+
+from omegaconf import OmegaConf
+
+
+class TestConfig(TestCase):
+
+    def test_build_strategy(self) -> None:
+        self.assertEqual('pull', Config.BuildStrategy.PULL)
+        self.assertEqual('auto', Config.BuildStrategy.AUTO)
+        self.assertEqual('always', Config.BuildStrategy.ALWAYS)
+
+        for strategy in ('pull', 'auto', 'always'):
+            Config.BuildStrategy.validate(strategy)
+
+        self.assertRaises(IllegalParameterValueError, Config.BuildStrategy.validate, 'push')
+
+    def test_merge(self) -> None:
+        config = OmegaConf.create({'docker': {'image': 'mlcommons/mnist:0.01'}})
+        Config.merge(config)
+        self.assertEqual(
+            config,
+            OmegaConf.create({
+                'runner': {'image': 'mlcommons/mnist:0.01'},
+                'docker': {'image': 'mlcommons/mnist:0.01'}
+            })
+        )
+
+    def test_validate(self) -> None:
+        config = OmegaConf.create({
+            'docker': {'image': 'mlcommons/mnist:0.01'},
+            'runner': Config.DEFAULT.copy()
+        })
+        Config.validate(config)
+
+        self.assertIsInstance(config.runner.build_args, str)
+        self.assertIsInstance(config.runner.env_args, str)

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest import TestCase
+from unittest.mock import (mock_open, patch)
+
+from omegaconf import DictConfig, OmegaConf
+
+from mlcube.config import MLCubeConfig
+from mlcube.shell import Shell
+
+from mlcube_docker.docker_run import (Config, DockerRun)
+
+_HAVE_DOCKER: bool = Shell.run(['docker', '--version'], on_error='ignore') == 0
+
+_MLCUBE_DEFAULT_ENTRY_POINT = """
+docker:
+  image: ubuntu:18.04
+tasks:
+  ls: {parameters: {inputs: {}, outputs: {}}}
+  pwd: {parameters: {inputs: {}, outputs: {}}}
+"""
+
+
+class TestDockerRunner(TestCase):
+
+    @staticmethod
+    def noop(*args, **kwargs) -> None:
+        ...
+
+    def setUp(self) -> None:
+        self.sync_workspace = Shell.sync_workspace
+        Shell.sync_workspace = TestDockerRunner.noop
+
+    def tearDown(self) -> None:
+        Shell.sync_workspace = self.sync_workspace
+
+    @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
+    def test_mlcube_default_entrypoints(self):
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+        )
+        self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
+        self.assertDictEqual(
+            OmegaConf.to_container(mlcube.tasks),
+            {
+                'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
+                'pwd': {'parameters': {'inputs': {}, 'outputs': {}}}
+            }
+        )
+
+        DockerRun(mlcube, task=None).configure()
+        DockerRun(mlcube, task='ls').run()
+        DockerRun(mlcube, task='pwd').run()

--- a/runners/mlcube_docker/mlcube_docker/tests/test_factory_fn.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_factory_fn.py
@@ -1,0 +1,15 @@
+import typing as t
+from unittest import TestCase
+
+import mlcube_docker
+from mlcube_docker.docker_run import DockerRun
+
+
+class TestFactoryFunction(TestCase):
+
+    def test_factory_fn(self) -> None:
+        self.assertTrue(hasattr(mlcube_docker, 'get_runner_class'))
+        self.assertTrue(callable(mlcube_docker.get_runner_class))
+
+        runner_cls: t.Type[DockerRun] = mlcube_docker.get_runner_class()
+        self.assertIs(runner_cls, DockerRun)


### PR DESCRIPTION
1. New unit tests for docker runner. Runner itself (configure/run methods) is tested of docker is available in the system. The test pulls `ubuntu:18.04` image (~ 64 MB).
2. `Config.merge`: if `runner` section is not present, it is automatically created.
3. Annotating `task` parameter as optional for the DockerRun.__init__ method.
4. Adding new method `Shell.null` that returns /dev/null variants for Linux/Window machines. The `Shell.docker_image_exists` method now works correctly in windows.