### PR TITLE
New unit tests for MLCube singularity runner.

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -48,6 +48,9 @@ class Config(RunnerConfig):
         Idea is that if mlcube contains `singularity` section, then it means that we use it as is. Else, we can try
         to run this MLCube using information from `docker` section if it exists.
         """
+        if 'runner' not in mlcube:
+            mlcube['runner'] = {}
+
         s_cfg: t.Optional[DictConfig] = mlcube.get("singularity", None)
         if not s_cfg:
             # Singularity runner will try to use docker section. At this point, it will work as long as we assume we
@@ -129,7 +132,7 @@ class SingularityRun(Runner):
                 "from singularity-cli python library (https://github.com/singularityhub/singularity-cli)."
             )
 
-    def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: str) -> None:
+    def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]) -> None:
         super().__init__(mlcube, task)
         try:
             # Check version and log a warning message if fakeroot is used with singularity version < 3.5

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from omegaconf import OmegaConf
+
+from mlcube_singularity.singularity_run import Config
+
+
+class TestConfig(TestCase):
+    def test_merge(self) -> None:
+        scfg = {'image': 'mnist-0.0.1.sif', 'image_dir': '/path/to/image', 'singularity': 'singularity'}
+        config = OmegaConf.create({
+            'singularity': scfg,
+            'runtime': {'workspace': '/path/to/workspace'}
+        })
+        Config.merge(config)
+        self.assertEqual(
+            config,
+            OmegaConf.create({
+                'runner': scfg,
+                'singularity': scfg,
+                'runtime': {'workspace': '/path/to/workspace'}
+            })
+        )
+
+    def test_validate(self) -> None:
+        config = OmegaConf.create({
+            'singularity': {'image': 'mnist-0.0.1.sif'},
+            'runtime': {'workspace': '/path/to/workspace'},
+            'runner': Config.DEFAULT.copy()
+        })
+        Config.validate(config)

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_factory_fn.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_factory_fn.py
@@ -1,0 +1,22 @@
+import typing as t
+import unittest
+from unittest import TestCase
+
+try:
+    # SPython does not work in Windows OS
+    import mlcube_singularity
+    from mlcube_singularity.singularity_run import SingularityRun
+except ImportError:
+    mlcube_singularity = None
+    SingularityRun = None
+
+
+class TestFactoryFunction(TestCase):
+
+    @unittest.skipUnless(SingularityRun is not None, reason="SPython is not available.")
+    def test_factory_fn(self) -> None:
+        self.assertTrue(hasattr(mlcube_singularity, 'get_runner_class'))
+        self.assertTrue(callable(mlcube_singularity.get_runner_class))
+
+        runner_cls: t.Type[SingularityRun] = mlcube_singularity.get_runner_class()
+        self.assertIs(runner_cls, SingularityRun)

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+from unittest import TestCase
+from unittest.mock import patch, mock_open
+
+from mlcube.config import MLCubeConfig
+from mlcube.shell import Shell
+from mlcube_singularity.singularity_run import Config, SingularityRun
+
+from omegaconf import DictConfig, OmegaConf
+
+from spython.utils.terminal import (
+     check_install as check_singularity_installed,
+)
+
+
+_HAVE_SINGULARITY: bool = check_singularity_installed(software='singularity')
+_IMAGE_DIRECTORY: Path = Path(tempfile.mkdtemp())
+
+_MLCUBE_DEFAULT_ENTRY_POINT = """
+singularity:
+  image: ubuntu-18.04.sif
+  image_dir: {IMAGE_DIRECTORY}
+tasks:
+  ls: {parameters: {inputs: {}, outputs: {}}}
+  pwd: {parameters: {inputs: {}, outputs: {}}}
+""".replace('{IMAGE_DIRECTORY}', _IMAGE_DIRECTORY.as_posix())
+
+
+class TestSingularityRunner(TestCase):
+    """Test singularity runner.
+
+    Run these tests with `pytest -s` to see the output of task executions to confirm they work.
+    """
+
+    @staticmethod
+    def noop(*args, **kwargs) -> None:
+        ...
+
+    def setUp(self) -> None:
+        self.sync_workspace = Shell.sync_workspace
+        Shell.sync_workspace = TestSingularityRunner.noop
+
+        if _HAVE_SINGULARITY:
+            if not _IMAGE_DIRECTORY.exists():
+                _IMAGE_DIRECTORY.mkdir(parents=True, exist_ok=True)
+            Shell.run(
+                ['singularity', 'build', (_IMAGE_DIRECTORY / 'ubuntu-18.04.sif').as_posix(), 'docker://ubuntu:18.04'],
+                on_error='raise'
+            )
+
+    def tearDown(self) -> None:
+        Shell.sync_workspace = self.sync_workspace
+        if _IMAGE_DIRECTORY.exists():
+            shutil.rmtree(_IMAGE_DIRECTORY.as_posix())
+
+    @unittest.skipUnless(_HAVE_SINGULARITY, reason="No singularity available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
+    def test_mlcube_default_entrypoints(self):
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=SingularityRun
+        )
+        self.assertEqual(mlcube.runner.image, 'ubuntu-18.04.sif')
+        self.assertDictEqual(
+            OmegaConf.to_container(mlcube.tasks),
+            {
+                'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
+                'pwd': {'parameters': {'inputs': {}, 'outputs': {}}}
+            }
+        )
+        SingularityRun(mlcube, task=None).configure()
+        SingularityRun(mlcube, task='ls').run()
+        SingularityRun(mlcube, task='pwd').run()


### PR DESCRIPTION
1. New unit tests for singularity runner. Runner itself (configure/run methods) is tested if singularity is available in the system. The test pulls `ubuntu:18.04` docker image (~ 64 MB) and creates corresponding SIF file as part of test setup.
2. `Config.merge`: if `runner` section is not present, it is automatically created.
3. Annotating `task` parameter as optional for the SingularityRun.__init__ method.