### PR TITLE
Custom entry points.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,4 +17,4 @@ ignore = D100
 # D103 Missing docstring in public function
 # D104 Missing docstring in public package
 per-file-ignores =
-     */tests/*: D101,D102,D103,D104
+     test_*.py: D101,D102,D103,D104

--- a/mlcube/mlcube/config.py
+++ b/mlcube/mlcube/config.py
@@ -134,6 +134,12 @@ class MLCubeConfig(object):
 
         for task_name in mlcube_config.tasks.keys():
             [task] = MLCubeConfig.ensure_values_exist(mlcube_config.tasks, task_name, dict)
+            if 'entrypoint' in task and task['entrypoint'] is None:
+                logger.warning(
+                    "MLCube task (%s) specifies an entrypoint that is None: removing it (a default "
+                    "entrypoint will be used).", task_name
+                )
+                task.pop('entrypoint')
             [parameters] = MLCubeConfig.ensure_values_exist(task, 'parameters', dict)
             [inputs, outputs] = MLCubeConfig.ensure_values_exist(parameters, ['inputs', 'outputs'], dict)
 
@@ -175,6 +181,8 @@ class MLCubeConfig(object):
             # Check again parameter type. Users in certain number of cases will not be providing final slash on a
             # command line for directories, so we tried to infer types above using default values. Just in case, see
             # if we can do the same with user-provided values.
+            # TODO: what if a parameter in mlcube.yaml is declared to be a file, but users provided something with
+            #       slash at the end.
             if param_def.type == ParameterType.UNKNOWN and param_def.default.endswith(os.sep):
                 param_def.type = ParameterType.DIRECTORY
 

--- a/mlcube/mlcube/tests/test_config.py
+++ b/mlcube/mlcube/tests/test_config.py
@@ -6,7 +6,7 @@ from mlcube.config import (IOType, MLCubeConfig, ParameterType)
 from omegaconf import (DictConfig, ListConfig, OmegaConf)
 
 
-_MLCUBE_MNIST_CONFIG = """
+_MLCUBE_MNIST_CONFIG_TEMPLATE = """
 name: mnist
 description: MLCommons MNIST MLCube example
 authors:
@@ -28,6 +28,7 @@ singularity:
 
 tasks:
   download:
+    {DOWNLOAD_ENTRY_POINT}
     parameters:
       inputs:
         data_config: {type: file, default: data.yaml}
@@ -44,10 +45,22 @@ tasks:
         model_dir: {type: directory, default: model}
 """
 
+_DOWNLOAD_TASK_ENTRY_POINT = '/workspace/mnist/download.py'
+
+_MLCUBE_MNIST_CONFIG = _MLCUBE_MNIST_CONFIG_TEMPLATE.replace(
+    '{DOWNLOAD_ENTRY_POINT}',
+    ''
+)
+
+_MLCUBE_MNIST_CONFIG_ENTRYPOINT = _MLCUBE_MNIST_CONFIG_TEMPLATE.replace(
+    '{DOWNLOAD_ENTRY_POINT}',
+    f'entrypoint: {_DOWNLOAD_TASK_ENTRY_POINT}'
+)
+
 
 class TestConfig(TestCase):
 
-    def _check_standard_config(self, mlcube: DictConfig) -> None:
+    def _check_standard_config(self, mlcube: DictConfig, entry_points: bool = False) -> None:
         self.assertIsInstance(mlcube, DictConfig)
 
         for key in ('name', 'description', 'authors',
@@ -84,34 +97,34 @@ class TestConfig(TestCase):
         self.assertDictEqual(OmegaConf.to_container(mlcube.singularity), {'image': 'mnist-0.0.1.sif'})
 
         self.assertIsInstance(mlcube.tasks, DictConfig)
-        self.assertDictEqual(
-            OmegaConf.to_container(mlcube.tasks),
-            {
-                'download': {
-                    'parameters': {
-                        'inputs': {
-                            'data_config': {'type': 'file', 'default': 'data.yaml'}
-                        },
-                        'outputs': {
-                            'data_dir': {'type': 'directory', 'default': 'data'},
-                            'log_dir': {'type': 'directory', 'default': 'logs'}
-                        }
+        expected_task_specs = {
+            'download': {
+                'parameters': {
+                    'inputs': {
+                        'data_config': {'type': 'file', 'default': 'data.yaml'}
                     },
+                    'outputs': {
+                        'data_dir': {'type': 'directory', 'default': 'data'},
+                        'log_dir': {'type': 'directory', 'default': 'logs'}
+                    }
                 },
-                'train': {
-                    'parameters': {
-                        'inputs': {
-                            'data_dir': {'type': 'directory', 'default': 'data'},
-                            'train_config': {'type': 'file', 'default': 'train.yaml'}
-                        },
-                        'outputs': {
-                            'log_dir': {'type': 'directory', 'default': 'logs'},
-                            'model_dir': {'type': 'directory', 'default': 'model'}
-                        }
+            },
+            'train': {
+                'parameters': {
+                    'inputs': {
+                        'data_dir': {'type': 'directory', 'default': 'data'},
+                        'train_config': {'type': 'file', 'default': 'train.yaml'}
+                    },
+                    'outputs': {
+                        'log_dir': {'type': 'directory', 'default': 'logs'},
+                        'model_dir': {'type': 'directory', 'default': 'model'}
                     }
                 }
             }
-        )
+        }
+        if entry_points:
+            expected_task_specs['download']['entrypoint'] = _DOWNLOAD_TASK_ENTRY_POINT
+        self.assertDictEqual(OmegaConf.to_container(mlcube.tasks), expected_task_specs)
 
         self.assertIsInstance(mlcube.runtime, DictConfig)
         self.assertDictEqual(
@@ -141,6 +154,11 @@ class TestConfig(TestCase):
 
         mlcube.docker.image = 'mlcommons/mnist:0.0.1'
         self._check_standard_config(mlcube)
+
+    @patch("io.open", mock_open(read_data=_MLCUBE_MNIST_CONFIG_ENTRYPOINT))
+    def test_create_mlcube_config_entrypoints(self) -> None:
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config("/some/path/to/mlcube.yaml")
+        self._check_standard_config(mlcube, entry_points=True)
 
     def test_io_type(self) -> None:
         self.assertEqual(IOType.INPUT, 'input')

--- a/runners/mlcube_docker/mlcube_docker/__init__.py
+++ b/runners/mlcube_docker/mlcube_docker/__init__.py
@@ -1,5 +1,62 @@
+"""MLCube reference docker runner.
+
+# Introduction
+Docker runner runs MLCubes using docker or its alternatives/competitors such as podman. MLCube configuration file
+must provide `docker` section with runner configuration. The only mandatory parameter is image name (image):
+```yaml
+docker:
+    image: ubuntu:18.04
+```
+Other supported parameters are listed in the default configuration (`mlcube_docker.docker_run.Config.DEFAULT`).
+
+# Configure
+MLCube docker runner builds or pulls docker images at configure phase (`mlcube configure ...`). As with other runners,
+users do not need to run this command explicitly. MLCube docker runner automatically identifies if it needs to configure
+MLCubes before running each task.
+
+> Docker runner will automatically run the configure command when running tasks in the following two
+> cases: (1) build strategy is 'always' or (2) docker does not exist locally. This means that if source code has
+> changed, the mlcube won't rebuild the image.
+
+The MLCube docker runner parameter `mlcube_docker.docker_run.Config.BuildStrategy` (`build_strategy`) defines how
+configuration is performed.
+
+# Run
+Docker runner supports tasks with and without custom entrypoints.
+
+For task that do not define entrypoints, Docker runner assumes docker images define entrypoints. These entrypoints are
+defined in Dockerfile build recipes, and are  executable scripts that accepts task name as their first positional
+arguments. Other task-specific arguments follow task name positional argument. In other words, task name and task
+arguments are COMMAND in docker terminology that docker will pass to image entry point.
+If image entry point is `python /workspace/mnist.py`, and current task is `download` with the single output directory
+parameter `data_dir` with value equal to `/datasets/mnist/`, the MLCube docker runner will build the following command:
+```shell
+docker run ... IMAGE_NAME download --data_dir=/datasets/mnist/
+```
+This will result in the following inside the docker container:
+```shell
+python /workspace/mnist.py download --data_dir=/datasets/mnist/
+```
+
+When tasks define their custom entry points, MLCube docker runner will override image entrypoint and will not be passing
+task name as the first positional argument to this custom entrypoint script. Looking at the example presented above, if
+the `download` task defines `/workspace/download.py` entrypoint, the MLCube docker runner will build the following
+command:
+```shell
+docker run ... --entrypoint=/workspace/download.py IMAGE_NAME --data_dir=/datasets/mnist/
+```
+This will result in the following inside the docker container:
+```shell
+python /workspace/download.py --data_dir=/datasets/mnist/
+```
+"""
 
 
 def get_runner_class():
+    """Return docker runner python class.
+
+    Returns:
+        DockerRun class.
+    """
     from mlcube_docker.docker_run import DockerRun
     return DockerRun

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -163,6 +163,12 @@ class DockerRun(Runner):
         env_args = self.mlcube.runner.env_args
         num_gpus: int = self.mlcube.platform.get('accelerator_count', None) or 0
         run_args: t.Text = self.mlcube.runner.cpu_args if num_gpus == 0 else self.mlcube.runner.gpu_args
+        if 'entrypoint' in self.mlcube.tasks[self.task]:
+            logger.info(
+                "Using custom task entrypoint: task=%s, entrypoint='%s'",
+                self.task, self.mlcube.tasks[self.task].entrypoint
+            )
+            run_args += f" --entrypoint='{self.mlcube.tasks[self.task].entrypoint}'"
         try:
             Shell.run([docker, 'run', run_args, env_args, volumes, image, ' '.join(task_args)])
         except ExecutionError as err:

--- a/runners/mlcube_docker/mlcube_docker/tests/test_config.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_config.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
-from mlcube_docker.docker_run import Config
 from mlcube.errors import IllegalParameterValueError
+
+from mlcube_docker.docker_run import Config
+
 
 from omegaconf import OmegaConf
 

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -2,12 +2,12 @@ import unittest
 from unittest import TestCase
 from unittest.mock import (mock_open, patch)
 
-from omegaconf import DictConfig, OmegaConf
-
 from mlcube.config import MLCubeConfig
 from mlcube.shell import Shell
 
 from mlcube_docker.docker_run import (Config, DockerRun)
+
+from omegaconf import DictConfig, OmegaConf
 
 _HAVE_DOCKER: bool = Shell.run(['docker', '--version'], on_error='ignore') == 0
 

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -19,6 +19,14 @@ tasks:
   pwd: {parameters: {inputs: {}, outputs: {}}}
 """
 
+_MLCUBE_CUSTOM_ENTRY_POINTS = """
+docker:
+  image: ubuntu:18.04
+tasks:
+  ls: {parameters: {inputs: {}, outputs: {}}}
+  free: {entrypoint: '/usr/bin/free', parameters: {inputs: {}, outputs: {}}}
+"""
+
 
 class TestDockerRunner(TestCase):
 
@@ -27,6 +35,15 @@ class TestDockerRunner(TestCase):
         ...
 
     def setUp(self) -> None:
+        """Configure testing environment.
+
+        Some unit tests patch the `io.open` function to bypass file-reading routine and use MLCube configuration
+        instead, which is stored in memory (e.g. _MLCUBE_DEFAULT_ENTRY_POINT). In this case I provide a fake path
+        (/some/path/to/mlcube.yaml) for the `MLCubeConfig.create_mlcube_config` method. Later, when this test runs
+        MLCubes, workspace is synced what results in an error (PermissionDenied). And we do not want to sync workspaces
+        anyway. So, here I manually patch the `Shell.sync_workspace` method making it a no-operations (noop) method
+        (could not figure out how to do it with @patch decorator).
+        """
         self.sync_workspace = Shell.sync_workspace
         Shell.sync_workspace = TestDockerRunner.noop
 
@@ -51,3 +68,22 @@ class TestDockerRunner(TestCase):
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
         DockerRun(mlcube, task='pwd').run()
+
+    @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS))
+    def test_mlcube_custom_entrypoints(self):
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+        )
+        self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
+        self.assertDictEqual(
+            OmegaConf.to_container(mlcube.tasks),
+            {
+                'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
+                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}}
+            }
+        )
+
+        DockerRun(mlcube, task=None).configure()
+        DockerRun(mlcube, task='ls').run()
+        DockerRun(mlcube, task='free').run()

--- a/runners/mlcube_singularity/mlcube_singularity/__init__.py
+++ b/runners/mlcube_singularity/mlcube_singularity/__init__.py
@@ -1,3 +1,39 @@
+"""MLCube reference singularity runner.
+
+# Introduction
+Singularity runner runs MLCubes using singularity. MLCube configuration can provide `singularity` section with runner
+configuration. The only mandatory parameter is image name (image):
+```yaml
+singularity:
+    image: ubuntu-18.04.sif
+```
+If no `singularity` section exists in mlcube.yaml, but `docker` section exists, the MLCube singularity runner will try
+to use that information. This will work for the following two cases:
+- Docker image does not need to be built locally, and is available at docker hub (in other words, can be pulled).
+- Docker section references docker archive (using `tar_file` docker configuration parameter).
+
+Other supported parameters are listed in the default configuration: `mlcube_singularity.singularity_run.Config.DEFAULT`.
+
+# Configure
+If SIF image file exists, no actions are performed (this means singularity runner will never rebuild the image file if,
+for instance, source files have changed). If no file exists, singularity will build SIF image either from docker image
+or docker archive file, or using local source files and Singularity recipe.
+
+# Run
+At run phase, the MLCube runner rune the `configure` command if SIF file does not exist. The runner runs tasks with and
+without custom entrypoints similar to Docker runner.
+If a task does not define its custom entrypoint, MLCube singularity runner assumes the image defines default entry
+point (`runscript`) that accepts a task name as its first positional argument, and task-specific arguments follow.
+The singularity runner `runs` the task in the following way:
+```shell
+singularity run ... TASK_NAME TASK_ARGS
+```
+If a task defines its entrypoint, the MLCube singularity runner will use the following command to `execute` the task:
+```
+singularity run ... ENTRY_POINT TASK_ARGS
+```
+Similarly to docker runner, no task name is provided.
+"""
 
 
 def get_runner_class():

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -211,6 +211,7 @@ class SingularityRun(Runner):
             )
 
         try:
+            # The `task_args` list of strings contains task name at the first position.
             mounts, task_args = Shell.generate_mounts_and_args(self.mlcube, self.task)
             logger.info(f"mounts={mounts}, task_args={task_args}")
         except ConfigurationError as err:
@@ -223,7 +224,19 @@ class SingularityRun(Runner):
 
         volumes = Shell.to_cli_args(mounts, sep=":", parent_arg="--bind")
         try:
-            Shell.run([self.mlcube.runner.singularity, 'run', self.mlcube.runner.run_args, volumes, str(image_file), ' '.join(task_args)])
+            entrypoint: t.Optional[str] = self.mlcube.tasks[self.task].get('entrypoint', None)
+            if entrypoint:
+                logger.info(
+                    "Using custom task entrypoint: task=%s, entrypoint='%s'",
+                    self.task, self.mlcube.tasks[self.task].entrypoint
+                )
+                Shell.run([self.mlcube.runner.singularity, 'exec', self.mlcube.runner.run_args, volumes,
+                           str(image_file), entrypoint, ' '.join(task_args[1:])])
+            else:
+                Shell.run([
+                    self.mlcube.runner.singularity, 'run', self.mlcube.runner.run_args, volumes,
+                    str(image_file), ' '.join(task_args)
+                ])
         except ExecutionError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-from omegaconf import OmegaConf
-
 from mlcube_singularity.singularity_run import Config
+
+from omegaconf import OmegaConf
 
 
 class TestConfig(TestCase):

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_factory_fn.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_factory_fn.py
@@ -2,18 +2,12 @@ import typing as t
 import unittest
 from unittest import TestCase
 
-try:
-    # SPython does not work in Windows OS
-    import mlcube_singularity
-    from mlcube_singularity.singularity_run import SingularityRun
-except ImportError:
-    mlcube_singularity = None
-    SingularityRun = None
+import mlcube_singularity
+from mlcube_singularity.singularity_run import SingularityRun
 
 
 class TestFactoryFunction(TestCase):
 
-    @unittest.skipUnless(SingularityRun is not None, reason="SPython is not available.")
     def test_factory_fn(self) -> None:
         self.assertTrue(hasattr(mlcube_singularity, 'get_runner_class'))
         self.assertTrue(callable(mlcube_singularity.get_runner_class))

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
@@ -1,19 +1,31 @@
-from pathlib import Path
+"""Unit tests for singularity runner.
+
+There's no automatic validation of test outputs now. Run tests with `pytest -s --log-cli-level=10` command to see
+all MLCube logs. In particular, for TestSingularityRunner::test_mlcube_custom_entrypoints tests one should see that
+indeed custom entry points are used. The log will contain the following lines:
+```shell
+mlcube_singularity.singularity_run:singularity_run.py:229 Using custom task entrypoint:
+    task=free, entrypoint='/usr/bin/free'
+mlcube.shell:shell.py:99 Command='singularity exec   /tmp/tmpljhf3drp/ubuntu-18.04.sif /usr/bin/free ' ...
+```
+When custom entrypoints are not used, singularity uses `run` command instead of `exec`.
+"""
 import shutil
 import tempfile
+import typing as t
 import unittest
+from pathlib import Path
 from unittest import TestCase
-from unittest.mock import patch, mock_open
+from unittest.mock import (mock_open, patch)
 
 from mlcube.config import MLCubeConfig
 from mlcube.shell import Shell
-from mlcube_singularity.singularity_run import Config, SingularityRun
+
+from mlcube_singularity.singularity_run import (Config, SingularityRun)
 
 from omegaconf import DictConfig, OmegaConf
 
-from spython.utils.terminal import (
-     check_install as check_singularity_installed,
-)
+from spython.utils.terminal import check_install as check_singularity_installed
 
 
 _HAVE_SINGULARITY: bool = check_singularity_installed(software='singularity')
@@ -29,6 +41,18 @@ tasks:
 """.replace('{IMAGE_DIRECTORY}', _IMAGE_DIRECTORY.as_posix())
 
 
+_MLCUBE_CUSTOM_ENTRY_POINTS = """
+singularity:
+  image: ubuntu-18.04.sif
+  image_dir: {IMAGE_DIRECTORY}
+tasks:
+  ls: {parameters: {inputs: {}, outputs: {}}}
+  free: {entrypoint: '/usr/bin/free', parameters: {inputs: {}, outputs: {}}}
+""".replace('{IMAGE_DIRECTORY}', _IMAGE_DIRECTORY.as_posix())
+
+_sync_workspace_fn: t.Optional[t.Callable] = None
+
+
 class TestSingularityRunner(TestCase):
     """Test singularity runner.
 
@@ -39,8 +63,10 @@ class TestSingularityRunner(TestCase):
     def noop(*args, **kwargs) -> None:
         ...
 
-    def setUp(self) -> None:
-        self.sync_workspace = Shell.sync_workspace
+    @classmethod
+    def setUpClass(cls) -> None:
+        global _sync_workspace_fn
+        _sync_workspace_fn = Shell.sync_workspace
         Shell.sync_workspace = TestSingularityRunner.noop
 
         if _HAVE_SINGULARITY:
@@ -51,8 +77,10 @@ class TestSingularityRunner(TestCase):
                 on_error='raise'
             )
 
-    def tearDown(self) -> None:
-        Shell.sync_workspace = self.sync_workspace
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if _sync_workspace_fn is not None:
+            Shell.sync_workspace = _sync_workspace_fn
         if _IMAGE_DIRECTORY.exists():
             shutil.rmtree(_IMAGE_DIRECTORY.as_posix())
 
@@ -73,3 +101,21 @@ class TestSingularityRunner(TestCase):
         SingularityRun(mlcube, task=None).configure()
         SingularityRun(mlcube, task='ls').run()
         SingularityRun(mlcube, task='pwd').run()
+
+    @unittest.skipUnless(_HAVE_SINGULARITY, reason="No singularity available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS))
+    def test_mlcube_custom_entrypoints(self):
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=SingularityRun
+        )
+        self.assertEqual(mlcube.runner.image, 'ubuntu-18.04.sif')
+        self.assertDictEqual(
+            OmegaConf.to_container(mlcube.tasks),
+            {
+                'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
+                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}}
+            }
+        )
+        SingularityRun(mlcube, task=None).configure()
+        SingularityRun(mlcube, task='ls').run()
+        SingularityRun(mlcube, task='free').run()


### PR DESCRIPTION
Currently, MLCube docker and singularity runners require that docker and singularity images define entry points that serve as dispatcher scripts for various tasks implemented in those MLCubes. 

This PR introduces a new feature - custom entry points for MLCube tasks:
```yaml
tasks:
  download:
    entrypoint: /workspace/download.py
    parameters:
      inputs:
        data_config: {type: file, default: data.yaml}
      outputs:
        data_dir: {type: directory, default: data}
        log_dir: {type: directory, default: logs}
```

### Technical details
- One MLCube can implement tasks with and without entry points. If for some task there's no custom entry point, a default image entry point must exist.
- When tasks do not define entry points and default image entry points are used, the first positional argument is always a task name.
- When tasks define entry points, no task name is provided to those entry points.
- Docker runner runs MLCubes with `run` command. When custom entry point is defined, the MLCube docker runner will pass `--entrypoint` parameter to docker.
- Singularity runner uses `run` command to run tasks without entry points, and `exec` command when custom entry points exist.


Unit tests for docker and singularity runners partially cover this new functionality using very simple MLCubes. More details are available in MLCube docker and singularity runners package descriptions (`__init__.py` files).