### PR TITLE
Bug fix for singularity runner unit test (not able to get singularity version)

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -85,9 +85,10 @@ class Config(RunnerConfig):
                     logger.warning(
                         "SingularityRun will not use --fakeroot CLI switch (version < 3.5)"
                     )
-            except:
+            except Exception as err:
                 logger.warning(
-                    "SingularityRun can't get singularity version (do you have singularity installed?)."
+                    "SingularityRun can't get singularity version (do you have singularity installed?). "
+                    "Source=Config.merge. Exception=%s", str(err), exc_info=True
                 )
 
             build_file = "docker://" + d_cfg["image"]
@@ -129,7 +130,9 @@ class SingularityRun(Runner):
                 f"{SingularityRun.__name__} runner failed to configure or to run MLCube.",
                 "SingularityRun check_install returned false ('singularity --version' failed to run). MLCube cannot "
                 "run singularity images unless this check passes. Singularity runner uses `check_install` function "
-                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli)."
+                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli).",
+                function='check_singularity_installed',
+                args={'software': singularity_exec}
             )
 
     def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]) -> None:
@@ -145,9 +148,10 @@ class SingularityRun(Runner):
                     "SingularityRun singularity version < 3.5, and it probably does not support --fakeroot "
                     "parameter that is present in MLCube configuration."
                 )
-        except:
+        except Exception as err:
             logger.warning(
-                "SingularityRun can't get singularity version (do you have singularity installed?)."
+                "SingularityRun can't get singularity version (do you have singularity installed?). "
+                "Source=SingularityRun.__init__. Exception=%s.", str(err), exc_info=True
             )
 
     def configure(self) -> None:

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import shutil
 import tempfile
@@ -12,11 +13,20 @@ from mlcube_singularity.singularity_run import Config, SingularityRun
 from omegaconf import DictConfig, OmegaConf
 
 from spython.utils.terminal import (
-     check_install as check_singularity_installed,
+    get_singularity_version_info,
+    check_install as check_singularity_installed,
 )
 
-
 _HAVE_SINGULARITY: bool = check_singularity_installed(software='singularity')
+if _HAVE_SINGULARITY and 'SPYTHON_SINGULARITY_VERSION' not in os.environ:
+    # Problem: get_singularity_version_info  function uses `subprocesss` to run `singularity --version` command, capture
+    #          its output in order to determine singularity version. Pytest seems to be altering standard input/output
+    #          so that the output is empty.
+    # This is temporary solution until we determine the actual problem and find the right way to capture outputs of
+    # commands running using `subprocess` module in different environments. This seems to be applicable not only to
+    # pytest environment.
+    os.environ['SPYTHON_SINGULARITY_VERSION'] = str(get_singularity_version_info())
+
 _IMAGE_DIRECTORY: Path = Path(tempfile.mkdtemp())
 
 _MLCUBE_DEFAULT_ENTRY_POINT = """


### PR DESCRIPTION
The problem is that when running unit tests for SingularityRun (configure/run) with pytest, the `spython` package cannot determine the singularity version - captured output of `singularity --version` command ran with `subprocess` module is empty. This commit introduces the temporary fix by setting the `SPYTHON_SINGULARITY_VERSION` environment variable before running any unit tests (this variable is used internally in `spython` - if it's not empty, `spython` does not run `singularity --version`).