### PR TITLE
Bug fix for not being able to detect singularity version in unit tests with spython package.

### DIFF
--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -34,11 +34,11 @@ class TestDockerRunner(TestCase):
         Shell.sync_workspace = self.sync_workspace
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
-    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
     def test_mlcube_default_entrypoints(self):
-        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-        )
+        with patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT)):
+            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+            )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),


### PR DESCRIPTION
This bug was because of patching `io.open` function at the method level using `unitest.mock` module. This patching is required to avoid loading MLCube configuration files from files in unit tests. Instead, test configurations are created in code. This method-level patching was impacting functionality of `subprocess` module, since that module uses `io.open` functions as well.

This commit moves patching from method-level to inside the affected methods. The patching is in effect only when MLCube test configurations are loaded now.