### PR TITLE
Add MLCube mount options support (Singularity and Docker)

### DIFF
--- a/mlcube/mlcube/config.py
+++ b/mlcube/mlcube/config.py
@@ -51,6 +51,24 @@ class ParameterType(object):
         return io in (ParameterType.FILE, ParameterType.DIRECTORY, ParameterType.UNKNOWN)
 
 
+class MountOption(object):
+    """Read-Write (rw) or Read-Only type of MLCube mount parameter."""
+
+    RW = 'rw'
+    """This parameter is reads-write parameter (e.g., path to data)."""
+
+    RO = 'ro'
+    """This parameter is read-only parameter"""
+
+    UNKNOWN = 'unknown'
+    """Type is unknown (only used internally)."""
+
+    @staticmethod
+    def is_valid(io: str) -> bool:
+        """Return true if string `opts` contain valid MountOption type."""
+        return io in (MountOption.RW, MountOption.RO)
+
+
 class MLCubeConfig(object):
     """Utilities to assemble effective MLCube configuration."""
 

--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -11,7 +11,7 @@ import typing as t
 from distutils import dir_util
 from pathlib import Path
 
-from mlcube.config import (IOType, ParameterType)
+from mlcube.config import (IOType, ParameterType, MountOption)
 from mlcube.errors import (ConfigurationError, ExecutionError)
 
 from omegaconf import DictConfig
@@ -147,7 +147,7 @@ class Shell(object):
                 -  A list of task arguments.
         """
         # First task argument is always the task name.
-        mounts, args = {}, [task]
+        mounts, args, mounts_opts = {}, [task], {}
 
         def _generate(_params: DictConfig, _io: str) -> None:
             """_params here is a dictionary containing input or output parameters.
@@ -198,11 +198,20 @@ class Shell(object):
                     mounts[_host_path] = new_mount
                     args.append('--{}={}'.format(_param_name, mounts[_host_path] + '/' + _file_name))
 
+                if "opts" in _param_def:
+                    if MountOption.is_valid(_param_def.opts):
+                        mounts_opts[_host_path] = _param_def.opts
+                    else:
+                        raise ConfigurationError(f"Invalid mount options: mount={task}, param={_param_name}, "
+                                                     f"opts={_param_def.opts}. Option is unknown and unable to identify")
+                else:
+                    mounts_opts[_host_path] = MountOption.RW
+
         params = mlcube.tasks[task].parameters
         _generate(params.inputs, IOType.INPUT)
         _generate(params.outputs, IOType.OUTPUT)
 
-        return mounts, args
+        return mounts, args, mounts_opts
 
     @staticmethod
     def to_cli_args(args: t.Mapping[str, t.Any], sep: str = '=', parent_arg: t.Optional[str] = None) -> str:

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -154,7 +154,7 @@ class DockerRun(Runner):
 
         # The 'mounts' dictionary maps host paths to container paths
         try:
-            mounts, task_args = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            mounts, task_args, _ = Shell.generate_mounts_and_args(self.mlcube, self.task)
         except ConfigurationError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -154,7 +154,10 @@ class DockerRun(Runner):
 
         # The 'mounts' dictionary maps host paths to container paths
         try:
-            mounts, task_args, _ = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            mounts, task_args, mounts_opts = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            if mounts_opts:
+                for key, value in mounts_opts.items():
+                    mounts[key]+=f':{value}'
         except ConfigurationError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -34,11 +34,11 @@ class TestDockerRunner(TestCase):
         Shell.sync_workspace = self.sync_workspace
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
-    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
     def test_mlcube_default_entrypoints(self):
-        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-        )
+        with patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT)):
+            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+            )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -85,9 +85,10 @@ class Config(RunnerConfig):
                     logger.warning(
                         "SingularityRun will not use --fakeroot CLI switch (version < 3.5)"
                     )
-            except:
+            except Exception as err:
                 logger.warning(
-                    "SingularityRun can't get singularity version (do you have singularity installed?)."
+                    "SingularityRun can't get singularity version (do you have singularity installed?). "
+                    "Source=Config.merge. Exception=%s", str(err), exc_info=True
                 )
 
             build_file = "docker://" + d_cfg["image"]
@@ -129,7 +130,9 @@ class SingularityRun(Runner):
                 f"{SingularityRun.__name__} runner failed to configure or to run MLCube.",
                 "SingularityRun check_install returned false ('singularity --version' failed to run). MLCube cannot "
                 "run singularity images unless this check passes. Singularity runner uses `check_install` function "
-                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli)."
+                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli).",
+                function='check_singularity_installed',
+                args={'software': singularity_exec}
             )
 
     def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]) -> None:
@@ -145,9 +148,10 @@ class SingularityRun(Runner):
                     "SingularityRun singularity version < 3.5, and it probably does not support --fakeroot "
                     "parameter that is present in MLCube configuration."
                 )
-        except:
+        except Exception as err:
             logger.warning(
-                "SingularityRun can't get singularity version (do you have singularity installed?)."
+                "SingularityRun can't get singularity version (do you have singularity installed?). "
+                "Source=SingularityRun.__init__. Exception=%s.", str(err), exc_info=True
             )
 
     def configure(self) -> None:

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -215,7 +215,10 @@ class SingularityRun(Runner):
             )
 
         try:
-            mounts, task_args = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            mounts, task_args, mounts_opts = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            if mounts_opts:
+                for key, value in mounts_opts.items():
+                    mounts[key]+=f':{value}'
             logger.info(f"mounts={mounts}, task_args={task_args}")
         except ConfigurationError as err:
             raise ExecutionError.mlcube_run_error(

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import shutil
 import tempfile
@@ -12,11 +13,20 @@ from mlcube_singularity.singularity_run import Config, SingularityRun
 from omegaconf import DictConfig, OmegaConf
 
 from spython.utils.terminal import (
-     check_install as check_singularity_installed,
+    get_singularity_version_info,
+    check_install as check_singularity_installed,
 )
 
-
 _HAVE_SINGULARITY: bool = check_singularity_installed(software='singularity')
+if _HAVE_SINGULARITY and 'SPYTHON_SINGULARITY_VERSION' not in os.environ:
+    # Problem: get_singularity_version_info  function uses `subprocesss` to run `singularity --version` command, capture
+    #          its output in order to determine singularity version. Pytest seems to be altering standard input/output
+    #          so that the output is empty.
+    # This is temporary solution until we determine the actual problem and find the right way to capture outputs of
+    # commands running using `subprocess` module in different environments. This seems to be applicable not only to
+    # pytest environment.
+    os.environ['SPYTHON_SINGULARITY_VERSION'] = str(get_singularity_version_info())
+
 _IMAGE_DIRECTORY: Path = Path(tempfile.mkdtemp())
 
 _MLCUBE_DEFAULT_ENTRY_POINT = """


### PR DESCRIPTION
# Singularity read only volumes

When defining the mounts there is the need to define if these volumes are going be used with read-only permissions, to allow users to define this, here is a new definition for the inputs and outputs in the `mlcube.yaml` file:

`opts: ro`

By default singularity will use rw (read-write) permissions. Users can use the option **"ro"** to define a read-only volume. 
[Singularity docs](https://docs.sylabs.io/guides/3.0/user-guide/bind_paths_and_mounts.html)

# Docker read only volumes

After checking the official [documentation](https://docs.docker.com/storage/volumes/#use-a-read-only-volume) from Docker, we can see that there is a slightly differnece in how Docker describes how to define read-only volumes, but after some testing, we discovered that it supports the same format, here is an example:

<img width="1430" alt="imagen" src="https://user-images.githubusercontent.com/13946484/185522254-3c674d0f-f24d-4ca5-8642-6586cf38b6a6.png">

So at the end we can use the same structure for both runners.

## MLCube YAML example:

```yaml
tasks:
  train:
    parameters:
      inputs:
        data_dir: { type: directory, default: data/, opts: ro }
        embeddings_dir: { type: directory, default: embeddings/, opts: ro }
        input_model_dir: { type: directory, default: model/, opts: ro }
      outputs:
        output_model: { type: directory, default: output/ }
```