### PR TITLE
Custom Entry Points when executable plus arguments specified for entrypoint for docker/podman

### DIFF
--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -226,9 +226,9 @@ class DockerRun(Runner):
                run_args += f" --entrypoint={self.mlcube.tasks[self.task].entrypoint}"
         
 
-        # Remove task name. According to MLCube rules, custom entry points do not require task name as their
-        # first positional arguments.
-        _ = task_args.pop(0)
+            # Remove task name. According to MLCube rules, custom entry points do not require task name as their
+            # first positional arguments.
+            _ = task_args.pop(0)
             
         try:
             if (('entrypoint' in self.mlcube.tasks[self.task]) and (len(shlex.split(self.mlcube.tasks[self.task].entrypoint)) > 1)) : 

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -201,33 +201,43 @@ class DockerRun(Runner):
         num_gpus: int = self.mlcube.get('platform', {}).get('accelerator_count', None) or 0
 
         run_args: t.Text = self.mlcube.runner.cpu_args if num_gpus == 0 else self.mlcube.runner.gpu_args
+        multi_args =False
         if 'entrypoint' in self.mlcube.tasks[self.task] and (not self.mlcube.tasks[self.task].entrypoint.isspace()):
             logger.info(
                 "Using custom task entrypoint: task=%s, entrypoint='%s'",
                 self.task, self.mlcube.tasks[self.task].entrypoint
             )
-            # TODO: What if entrypoints contain whitespaces?
+            # What if entrypoints contain whitespaces e.g. "python /workspace/download.py" ?
             if " " in  self.mlcube.tasks[self.task].entrypoint:
                # use first item in entry point list as the executable to specify in docker run --entrypoint
+               # use second item in entrypont list as the argument to the executable in docker run --entrypoint 
+               # aruguments to executable must appear after the image name.  "docker run --entrypoint executable imagename args-for-executable"
+               # Check whether the mlcube --task matches the stem of the .py or .sh file specified in --entrypoint
+               multi_args = True
+               if task_args[0] == Path(shlex.split(self.mlcube.tasks[self.task].entrypoint)[1]).stem :
+                 # the mlcube --task does not match the stem of the .py or .sh file specified in --entrypoint
+                 logger.info("the mlcube --task does not match the stem of the entry point %s specified in mlcube.yaml",
+                              Path(shlex.split(self.mlcube.tasks[self.task].entrypoint)[1]).stem)
                run_args += f" --entrypoint={shlex.split(self.mlcube.tasks[self.task].entrypoint)[0]}" 
                
             else:
                run_args += f" --entrypoint={self.mlcube.tasks[self.task].entrypoint}"
-            # Remove task name. According to MLCube rules, custom entry points do not require task name as their
-            # first positional arguments.
-            # Check whether the mlcube --task matches the stem of the .py or .sh file specified in --entrypoint
-            if task_args[0] == Path(shlex.split(self.mlcube.tasks[self.task].entrypoint)[1]).stem : 
-              _ = task_args.pop(0)
-            else:
-                # the mlcube --task does not match the stem of the .py or .sh file specified in --entrypoint 
-                logger.info("the mlcube --task does not match the stem of the entry point %s specified in mlcube.yaml",
-                             Path(shlex.split(self.mlcube.tasks[self.task].entrypoint)[1]).stem)
+        # Remove task name. According to MLCube rules, custom entry points do not require task name as their
+        # first positional arguments.
+        _ = task_args.pop(0)
             
         try:
-            if 'entrypoint' in self.mlcube.tasks[self.task] and (not self.mlcube.tasks[self.task].entrypoint.isspace()): 
+            if 'entrypoint' in self.mlcube.tasks[self.task] and multi_args : 
+              # entrypoint of form "python something.py" or "sh something.sh"
               Shell.run([docker, 'run', run_args, env_args, volumes, image, shlex.split(self.mlcube.tasks[self.task].entrypoint)[1],' '.join(task_args)])
-            else:
+            elif 'entrypoint' in self.mlcube.tasks[self.task] and  (not self.mlcube.tasks[self.task].entrypoint.isspace()): 
+              Shell.run([docker, 'run', run_args, env_args, volumes, image])
+            elif  'entrypoint' in self.mlcube.tasks[self.task] and  (self.mlcube.tasks[self.task].entrypoint.isspace()): 
+              #  'entrypoint' but no entrypont value given 
               Shell.run([docker, 'run', run_args, env_args, volumes, image, ' '.join(task_args)])
+            else:
+              #  no entrypoint specified, take default entrypoint
+              Shell.run([docker, 'run', run_args, env_args, volumes, image, ' '.join(task_args)])   
 
         except ExecutionError as err:
             raise ExecutionError.mlcube_run_error(

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -51,11 +51,11 @@ class TestDockerRunner(TestCase):
         Shell.sync_workspace = self.sync_workspace
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
     def test_mlcube_default_entrypoints(self):
-        with patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT)):
-            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-            )
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+        )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),
@@ -67,14 +67,14 @@ class TestDockerRunner(TestCase):
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
-        #DockerRun(mlcube, task='pwd').run()
+        DockerRun(mlcube, task='pwd').run()
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
+    @patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS))
     def test_mlcube_custom_entrypoints(self):
-        with patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS)):
-            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-            )
+        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+        )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),
@@ -86,4 +86,4 @@ class TestDockerRunner(TestCase):
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
-        #DockerRun(mlcube, task='pwd').run()
+        DockerRun(mlcube, task='free').run()

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -25,6 +25,7 @@ docker:
 tasks:
   ls: {parameters: {inputs: {}, outputs: {}}}
   free: {entrypoint: '/usr/bin/free', parameters: {inputs: {}, outputs: {}}}
+  bash: {entrypoint: '/bin/bash', parameters: {inputs: {}, outputs: {}}}
 """
 
 
@@ -80,10 +81,12 @@ class TestDockerRunner(TestCase):
             OmegaConf.to_container(mlcube.tasks),
             {
                 'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
-                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}}
+                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}},
+                'bash': {'entrypoint': '/bin/bash', 'parameters': {'inputs': {}, 'outputs': {}}},
             }
         )
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
         DockerRun(mlcube, task='free').run()
+        DockerRun(mlcube, task='bash').run()

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -67,7 +67,7 @@ class TestDockerRunner(TestCase):
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
-        DockerRun(mlcube, task='pwd').run()
+        #DockerRun(mlcube, task='pwd').run()
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
     def test_mlcube_custom_entrypoints(self):
@@ -86,4 +86,4 @@ class TestDockerRunner(TestCase):
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
-        DockerRun(mlcube, task='free').run()
+        #DockerRun(mlcube, task='pwd').run()

--- a/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_docker_runner.py
@@ -25,7 +25,6 @@ docker:
 tasks:
   ls: {parameters: {inputs: {}, outputs: {}}}
   free: {entrypoint: '/usr/bin/free', parameters: {inputs: {}, outputs: {}}}
-  bash: {entrypoint: '/bin/bash', parameters: {inputs: {}, outputs: {}}}
 """
 
 
@@ -52,11 +51,11 @@ class TestDockerRunner(TestCase):
         Shell.sync_workspace = self.sync_workspace
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
-    @patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT))
     def test_mlcube_default_entrypoints(self):
-        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-        )
+        with patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT)):
+            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+            )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),
@@ -71,22 +70,20 @@ class TestDockerRunner(TestCase):
         DockerRun(mlcube, task='pwd').run()
 
     @unittest.skipUnless(_HAVE_DOCKER, reason="No docker available.")
-    @patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS))
     def test_mlcube_custom_entrypoints(self):
-        mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-            "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
-        )
+        with patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS)):
+            mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
+                "/some/path/to/mlcube.yaml", runner_config=Config.DEFAULT, runner_cls=DockerRun
+            )
         self.assertEqual(mlcube.runner.image, 'ubuntu:18.04')
         self.assertDictEqual(
             OmegaConf.to_container(mlcube.tasks),
             {
                 'ls': {'parameters': {'inputs': {}, 'outputs': {}}},
-                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}},
-                'bash': {'entrypoint': '/bin/bash', 'parameters': {'inputs': {}, 'outputs': {}}},
+                'free': {'entrypoint': '/usr/bin/free', 'parameters': {'inputs': {}, 'outputs': {}}}
             }
         )
 
         DockerRun(mlcube, task=None).configure()
         DockerRun(mlcube, task='ls').run()
         DockerRun(mlcube, task='free').run()
-        DockerRun(mlcube, task='bash').run()


### PR DESCRIPTION
This PR fixes an issue in the custom entrypoints feature. 
( recently merged PR Custom entry points. #263 )

This fix is needed in the docker runner. 

The custom entrypoints feature in MLCube (for docker and podman) is implemented using
docker's  --entrypoint option on the  "docker run" command line. 

We override the ENTRYPOINT (specified in the docker image) with the docker run --entrypoint option. 
Docker requires that you specify the options for the new entrypoint as follows: 
docker run --entrypoint [new_command] [docker_image] [optional:value]. 

In the  mlcube.yaml example below we specify a custom entrypoint of "python3 /workspace/download.py"
this means you must call docker run as follows:
docker run --entrypoint python3  [docker_image] /workspace/download.py

Note:  python3 is an executable, the --entrypoint option is expecting an executable (e.g. python, bash, etc) plus possible options (e.g. *.py or *.sh).  The options for the executable need to be specified after the [docker_image] and this PR (#268) makes that required change to the original custom entrypoints feature (PR #263).  

# mlcube.yaml excerpt
tasks:
  download:
    entrypoint:  python3 /workspace/download.py
    parameters:
      inputs:
        data_config: {type: file, default: data.yaml}
      outputs:
        data_dir: {type: directory, default: data}
        log_dir: {type: directory, default: logs}