### PR TITLE
PyPi publish GitHub actions update.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
         cd mlcube
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true

--- a/.github/workflows/runner-publish.yml
+++ b/.github/workflows/runner-publish.yml
@@ -25,7 +25,7 @@ jobs:
         cd runners/mlcube_ssh
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: sub-mod/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
@@ -53,7 +53,7 @@ jobs:
         cd runners/mlcube_docker
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
@@ -82,7 +82,7 @@ jobs:
         cd runners/mlcube_singularity
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
@@ -111,7 +111,7 @@ jobs:
         cd runners/mlcube_k8s
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
@@ -140,7 +140,7 @@ jobs:
         cd runners/mlcube_gcp
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
@@ -169,7 +169,7 @@ jobs:
           cd runners/mlcube_kubeflow
           python setup.py sdist bdist_wheel
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.PYPI_USER }}
           verify_metadata: true


### PR DESCRIPTION
Updating due to the following warning:
```
You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.
```