### PR TITLE
Updating python version for CI docs from 3.6 to 3.8

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
MLCube uses `mkdocs-click` extension to automatically build web documentation pages for MLCube CLI. This library requires python version >= 3.7.