### PR TITLE
Ubuntu version downgrade for CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Currently, python 3.8.5 is used for unit tests and documentation deployment. GitHub has recently transitioned from ubuntu-20.04 to ubuntu-22.04 (for ubuntu-latest) what seems to be causing failures. Until we test CI pipelines with newest python version, downgrade to ubuntu-20.04 is needed.