### PR TITLE
Fixing mkdocs theme bug.

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -3,8 +3,9 @@ name: Build & Deploy Docs Site (on-merge)
 on:
   push:
     paths:
-    - 'docs/**'
     - '.github/workflows/docs-site.yml'
+    - 'docs/**'
+    - 'mkdocs.yml'
 
 jobs:
   docs:
@@ -23,7 +24,7 @@ jobs:
         working-directory: './'
         run: |
           export PYTHONPATH=$(pwd)/mlcube:${PYTHONPATH}
-          mkdocs build --theme material --site-dir ../site/
+          mkdocs build --site-dir ../site/
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.6.4
         with:


### PR DESCRIPTION
It seems that the mkdocs theme on a command line overrides the one in the mldocs.yml file. Removing `--theme material` CLI argument for docs-site.yml workflow (`Build Docs` step).