### PR TITLE
Updating click version.

### DIFF
--- a/mlcube/mlcube/__main__.py
+++ b/mlcube/mlcube/__main__.py
@@ -1,6 +1,7 @@
 """This requires the MLCube 2.0 that's located somewhere in one of dev branches."""
 import logging
 import os
+import shutil
 import sys
 import typing as t
 
@@ -19,8 +20,9 @@ from omegaconf import OmegaConf
 logger = logging.getLogger(__name__)
 
 
-_TERMINAL_WIDTH = click.termui.get_terminal_size()[0]
-"""Width of a user terminal. MLCube overrides default (80) character width to make usage examples look better."""
+_TERMINAL_WIDTH = shutil.get_terminal_size()[0]
+"""Width (number of columns) of a user terminal. 
+MLCube overrides default (80) character width to make usage examples look better."""
 
 
 @click.group(name='mlcube', add_help_option=False)

--- a/mlcube/mlcube/cli.py
+++ b/mlcube/mlcube/cli.py
@@ -4,7 +4,6 @@ from io import StringIO
 from xml.etree.ElementTree import Element
 
 import click
-from click.core import DEPRECATED_HELP_NOTICE
 
 from markdown import Markdown
 
@@ -20,6 +19,9 @@ from mlcube.platform import Platform
 from mlcube.runner import Runner
 from mlcube.system_settings import SystemSettings
 from mlcube.validate import Validate
+
+
+DEPRECATED_HELP_NOTICE = '(DEPRECATED)'
 
 
 def parse_cli_args(ctx: t.Optional[t.Union[click.core.Context, t.List[str]]],

--- a/mlcube/requirements.txt
+++ b/mlcube/requirements.txt
@@ -4,7 +4,7 @@ pytest-cov>=2.5, <3.0
 pytest-mock>=1.7.1,<2.0
 pytest>=5.0, <6.0
 wheel==0.32.2
-click==7.1.2
+click>=8.0.0,<9.0.0
 halo==0.0.30
 coloredlogs==14.0
 cookiecutter==1.7.2

--- a/runners/mlcube_docker/requirements.txt
+++ b/runners/mlcube_docker/requirements.txt
@@ -1,3 +1,3 @@
-click==7.1.2
+click>=8.0.0,<9.0.0
 mlcube==0.0.8
 omegaconf==2.1.0

--- a/runners/mlcube_gcp/requirements.txt
+++ b/runners/mlcube_gcp/requirements.txt
@@ -1,4 +1,4 @@
-click==7.1.2
+click>=8.0.0,<9.0.0
 mlcube==0.0.8
 google-api-python-client==1.12.5
 ssh-config==0.0.22

--- a/runners/mlcube_k8s/requirements.txt
+++ b/runners/mlcube_k8s/requirements.txt
@@ -1,4 +1,4 @@
-click==7.1.2
+click>=8.0.0,<9.0.0
 mlcube==0.0.8
 kubernetes==12.0.0
 diagrams==0.17.0

--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,3 +1,3 @@
-click==7.1.2
+click>=8.0.0,<9.0.0
 mlcube==0.0.8
 spython==0.2.1

--- a/runners/mlcube_ssh/requirements.txt
+++ b/runners/mlcube_ssh/requirements.txt
@@ -1,3 +1,3 @@
-click==7.1.2
+click>=8.0.0,<9.0.0
 mlcube==0.0.8
 omegaconf==2.1.0


### PR DESCRIPTION
This PR addresses the  #287 issue: updating click version from `7.1.2` to `>=8.0.0,<9.0.0`. This required several updates:
1. Several `requirements.txt` files.
2. Starting version [8.1.0](https://github.com/pallets/click/blob/main/CHANGES.rst#version-810), the `get_terminal_size` is not available. MLCube now uses `shutil.get_terminal_size` instead.
3. I guess starting 8.x version, click does not provide `DEPRECATED_HELP_NOTICE` variable due to changes in how click handles deprecated commands. Since this is just a string, MLCube redefines it in `cli.py` file.

TODO (in subsequent PRs)
1. Update and test the `MLCubeCommand` class implementation. At least, MLCube needs to be consistent with click formatting guidelines in terms of printing help messages.
2. Need unit tests to check conflicts of dependencies.