### PR TITLE
Support for `~` and environment variables in MLCube parameters.

### DIFF
--- a/docs/getting-started/mlcube-configuration.md
+++ b/docs/getting-started/mlcube-configuration.md
@@ -81,11 +81,16 @@ Each task configuration is a dictionary with two parameters:
   defines one input parameter (`data_config`) and two output parameters (`data_dir` and `log_dir`). Each parameter 
   description is a dictionary with the following fields:
     - `type (type=string)` Specifies parameter type, and must be one of `file` or `directory`.
-    - `default (type=string)` Default parameter value. If file system paths here are relative, then they are considered to
-      be relative with respect to 
-      [MLCube workspace](https://mlcommons.github.io/mlcube/getting-started/concepts/#workspace). In other words,
-      the `data_conig` parameter's default value for the `download` task specified above is a short form of 
-      `${workspace}/data.yaml`. 
+    - `default (type=string)` Parameter value: path to a directory of path to a file. 
+      - Paths can contain `~` (user home directory) and environment variables (e.g., `${HOME}`). MLCube does not 
+        encourage the use of environment variables  since this makes MLCube less portable and reproducible. The use 
+        of `~` should be OK though.
+      - Paths can be absolute or relative. Relative paths are always relative to current  
+        [MLCube workspace](https://mlcommons.github.io/mlcube/getting-started/concepts/#workspace) directory. 
+        In the example above,  the `data_conig` parameter's default value for the `download` task is a short form of 
+        `${workspace}/data.yaml`. 
+    - `opts (type=string)` This optional field specifies file or path access options (e.g., mount options for container
+      runtimes). Valid values are `rw` (read and write) and `ro` (read only).
 
 
 ## Examples


### PR DESCRIPTION
MLCube contract says relative paths in MLCube configuration files are relative with respect to MLCube workspace directory. In certain cases it makes sense to use absolute paths too. This maybe the case when we want to reuse host cache directories that many machine learning frameworks use to cache models and datasets. We also need to be able to resolve `~` (user home directory), as well as environment variables (BTW, this is probably needs some discussion at some point in time). This environment variable could be, for instance, `${HOME}`.

This commit:
- Adds support for `~` and environment variables on MLCube parameters.
- Explicitly deals with absolute and relative paths in the code. Previously, the implementation always concatenated workspace directory with parameter value. Now it is only done for relative paths.
- Updates documentation with description of absolute and relative paths.
- Not directly related to this feature, documentation now mentions that users can specify access options for parameters (which are file system paths) - `ro` (read only) and `rw` (read and write).