### PR TITLE
Updates to how MLCube generates volumes for containers.

### DIFF
--- a/docs/getting-started/mlcube-configuration.md
+++ b/docs/getting-started/mlcube-configuration.md
@@ -82,15 +82,18 @@ Each task configuration is a dictionary with two parameters:
   description is a dictionary with the following fields:
     - `type (type=string)` Specifies parameter type, and must be one of `file` or `directory`.
     - `default (type=string)` Parameter value: path to a directory of path to a file. 
-      - Paths can contain `~` (user home directory) and environment variables (e.g., `${HOME}`). MLCube does not 
-        encourage the use of environment variables  since this makes MLCube less portable and reproducible. The use 
-        of `~` should be OK though.
-      - Paths can be absolute or relative. Relative paths are always relative to current  
-        [MLCube workspace](https://mlcommons.github.io/mlcube/getting-started/concepts/#workspace) directory. 
-        In the example above,  the `data_conig` parameter's default value for the `download` task is a short form of 
-        `${workspace}/data.yaml`. 
+        - Paths can contain `~` (user home directory) and environment variables (e.g., `${HOME}`). MLCube does not 
+          encourage the use of environment variables  since this makes MLCube less portable and reproducible. The use 
+          of `~` should be OK though.
+        - Paths can be absolute or relative. Relative paths are always relative to current  
+          [MLCube workspace](https://mlcommons.github.io/mlcube/getting-started/concepts/#workspace) directory. 
+          In the example above,  the `data_conig` parameter's default value for the `download` task is a short form of 
+          `${workspace}/data.yaml`. 
     - `opts (type=string)` This optional field specifies file or path access options (e.g., mount options for container
-      runtimes). Valid values are `rw` (read and write) and `ro` (read only).
+      runtimes). Valid values are `rw` (read and write) and `ro` (read only). When parameter is a file, these options 
+      are set for a volume associated with the file's parent directory. When read-only option is specified for
+      an output parameter, MLCube runner will use it and will log to a log file. When conflicting options are 
+      found, MLCube will log a warning message and will use the `rw` option. 
 
 
 ## Examples

--- a/mlcube/mlcube/config.py
+++ b/mlcube/mlcube/config.py
@@ -15,7 +15,7 @@ from omegaconf import (DictConfig, OmegaConf)
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['IOType', 'ParameterType', 'MLCubeConfig']
+__all__ = ['IOType', 'ParameterType', 'MountType', 'MLCubeConfig']
 
 
 class IOType(object):

--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -138,28 +138,64 @@ class Shell(object):
         return Shell.run(f"rsync -e 'ssh' '{source}' '{dest}'", on_error=on_error)
 
     @staticmethod
-    def generate_mounts_and_args(mlcube: DictConfig, task: str) -> t.Tuple[t.Dict, t.List]:
-        """Generate mount points and arguments for the given task.
+    def get_host_path(workspace_path: str, path_from_config: str) -> str:
+        """Return host path for a task parameter.
 
+        Args:
+            workspace_path: Workspace directory path for this MLCube.
+            path_from_config: Parameter path as specified by a user in an MLCube configuration file (e.g., mlcube.yaml).
+
+        Returns:
+            Absolute host path.
+        """
+        # Omega conf will resolve any variables defined in MLCube configuration file. We need to take care about `~`
+        # (user home directory) and environment variables.
+        host_path = Path(
+            os.path.expandvars(os.path.expanduser(path_from_config))
+        )
+        # According to MLCube contract, relative paths are relative to MLCube workspace directory.
+        if not host_path.is_absolute():
+            host_path = Path(workspace_path) / host_path
+        return host_path.as_posix()
+
+    @staticmethod
+    def generate_mounts_and_args(mlcube: DictConfig, task: str,
+                                 make_dirs: bool = True) -> t.Tuple[t.Dict, t.List, t.Dict]:
+        """Generate mount points, task arguments and mount options for the given task.
+
+        Args:
+            mlcube: MLCube configuration (e.g., coming from `mlcube.yaml` file).
+            task: Task name for which mount points need to be generated.
+            make_dirs: If true, make host directories recursively if they do not exist. We need this to actually make
+                unit tests work (that set this value to false).
         Return:
-            A tuple containing two elements:
-                -  A mapping from host path to path inside container.
-                -  A list of task arguments.
+            A tuple containing three elements:
+                - A mapping from host path to path inside container.
+                - A list of task arguments.
+                - A mapping from host paths to mount options (optional).
         """
         # First task argument is always the task name.
-        mounts, args, mounts_opts = {}, [task], {}
+        mounts: t.Dict[str, str] = {}         # Mapping from host paths to container paths.
+        args: t.List[str] = [task]            # List of arguments for the given task.
+        mounts_opts: t.Dict[str, str] = {}    # Mapping from host paths to mount options (rw/ro).
 
         def _generate(_params: DictConfig, _io: str) -> None:
-            """_params here is a dictionary containing input or output parameters.
+            """Process parameters (could be inputs or outputs).
 
-            It maps parameter name to DictConfig(type, default)
+            This function updates `mounts`, `args` and `mounts_opts`.
+
+            Args:
+                _params: Dictionary of input or output parameters.
+                _io: Specifies if these parameters are input our output parameters.
             """
             if not IOType.is_valid(_io):
                 raise ConfigurationError(f"Invalid IO = {_io}")
             for _param_name, _param_def in _params.items():
+                assert isinstance(_param_def, DictConfig), f"Unexpected parameter definition: {_param_def}."
                 if not ParameterType.is_valid(_param_def.type):
-                    raise ConfigurationError(f"Invalid task: task={task}, param={_param_name}, "
-                                             f"type={_param_def.type}. Type is invalid.")
+                    raise ConfigurationError(
+                        f"Invalid task: task={task}, param={_param_name}, type={_param_def.type}. Type is invalid."
+                    )
 
                 # MLCube contract says relative paths in MLCube configuration files are relative with respect to MLCube
                 # workspace directory. In certain cases it makes sense to use absolute paths too. This maybe the case
@@ -167,62 +203,65 @@ class Shell(object):
                 # and datasets. We also need to be able to resolve `~` (user home directory), as well as environment
                 # variables (BTW, this is probably needs some discussion at some point in time). This environment
                 # variable could be, for instance, `${HOME}`.
-                _param_path = Path(
-                    os.path.expandvars(os.path.expanduser(_param_def.default))
-                )
-                if _param_path.is_absolute():
-                    _host_path = _param_path
-                else:
-                    _host_path = Path(mlcube.runtime.workspace) / _param_path
+                _host_path: str = Shell.get_host_path(mlcube.runtime.workspace, _param_def.default)
 
                 if _param_def.type == ParameterType.UNKNOWN:
                     if _io == IOType.OUTPUT:
-                        raise ConfigurationError(f"Invalid task: task={task}, param={_param_name}, "
-                                                 f"type={_param_def.type}. Type is unknown.")
+                        raise ConfigurationError(
+                            f"Invalid task: task={task}, param={_param_name}, type={_param_def.type}. "
+                            "Type cannot be unknown for output parameters."
+                        )
                     else:
                         if os.path.isdir(_host_path):
                             _param_def.type = ParameterType.DIRECTORY
                         elif os.path.isfile(_host_path):
                             _param_def.type = ParameterType.FILE
                         else:
-                            raise ConfigurationError(f"Invalid task: task={task}, param={_param_name}, "
-                                                     f"type={_param_def.type}. Type is unknown and unable to identify "
-                                                     f"it ({_host_path}).")
+                            raise ConfigurationError(
+                                f"Invalid task: task={task}, param={_param_name}, type={_param_def.type}. "
+                                f"Type is unknown and unable to identify it ({_host_path})."
+                            )
 
                 if _param_def.type == ParameterType.DIRECTORY:
-                    os.makedirs(_host_path, exist_ok=True)
-                    mounts[_host_path] = mounts.get(
-                        _host_path,
-                        '/mlcube_io{}/{}'.format(len(mounts), os.path.basename(_host_path))
-                    )
+                    if make_dirs:
+                        os.makedirs(_host_path, exist_ok=True)
+                    mounts[_host_path] = mounts.get(_host_path, f"/mlcube_io{len(mounts)}")
                     args.append('--{}={}'.format(_param_name, mounts[_host_path]))
                 elif _param_def.type == ParameterType.FILE:
                     _host_path, _file_name = os.path.split(_host_path)
-                    os.makedirs(_host_path, exist_ok=True)
-                    new_mount = mounts.get(
-                        _host_path,
-                        '/mlcube_io{}/{}'.format(len(mounts), _host_path)
-                    )
-                    windows_match = ':\\'
-                    if windows_match in new_mount:
-                        index = new_mount.index(windows_match)
-                        substring = new_mount[index - 1: index + 2]
-                        new_mount = new_mount.replace(substring, '').replace('\\', '/')
-                    mounts[_host_path] = new_mount
+                    if make_dirs:
+                        os.makedirs(_host_path, exist_ok=True)
+                    mounts[_host_path] = mounts.get(_host_path, f"/mlcube_io{len(mounts)}")
                     args.append('--{}={}'.format(_param_name, mounts[_host_path] + '/' + _file_name))
 
-                if "opts" in _param_def:
-                    if MountType.is_valid(_param_def.opts):
-                        mounts_opts[_host_path] = _param_def.opts
-                    else:
-                        raise ConfigurationError(f"Invalid mount options: mount={task}, param={_param_name}, "
-                                                     f"opts={_param_def.opts}. Option is unknown and unable to identify")
-                else:
-                    mounts_opts[_host_path] = MountType.RW
+                mount_type: t.Optional[str] = _param_def.get('opts', None)
+                if mount_type:
+                    if not MountType.is_valid(_param_def.opts):
+                        raise ConfigurationError(
+                            f"Invalid mount options: mount={task}, param={_param_name}, opts={_param_def.opts}."
+                        )
+                    if mount_type == MountType.RO and _io == IOType.OUTPUT:
+                        logger.warning(
+                            "Task's (%s) parameter (%s) is OUTPUT and requested to mount as RO.", task, _param_name
+                        )
+                    if _host_path in mounts_opts and mounts_opts[_host_path] != mount_type:
+                        logger.warning(
+                            "Conflicting mount options found. Host path (%s) has already been requested to mount as "
+                            "'%s', but new parameter (%s) requests to mount as '%s'.",
+                            _host_path, mounts_opts[_host_path], _param_name, mount_type
+                        )
+                        # Since we can only have `ro`/`rw`, we'll set the mount option to `rw`.
+                        mount_type = MountType.RW
 
-        params = mlcube.tasks[task].parameters
-        _generate(params.inputs, IOType.INPUT)
-        _generate(params.outputs, IOType.OUTPUT)
+                    mounts_opts[_host_path] = mount_type
+                    logger.info(
+                        "Host path (%s) for parameter '%s' will be mounted with '%s' option.",
+                        _host_path, _param_name, mount_type
+                    )
+
+        params = mlcube.tasks[task].parameters     # Dictionary of input and output parameters for the task.
+        _generate(params.inputs, IOType.INPUT)     # Process input parameters.
+        _generate(params.outputs, IOType.OUTPUT)   # Process output parameters.
 
         return mounts, args, mounts_opts
 

--- a/mlcube/mlcube/tests/test_shell.py
+++ b/mlcube/mlcube/tests/test_shell.py
@@ -1,7 +1,10 @@
+import typing as t
 from unittest import TestCase
 
 from mlcube.errors import ExecutionError
 from mlcube.shell import Shell
+
+from omegaconf import DictConfig
 
 
 class TestShell(TestCase):
@@ -24,3 +27,71 @@ class TestShell(TestCase):
     def test_run_03(self) -> None:
         with self.assertRaises(ExecutionError):
             _ = Shell.run('python -c "print(message)"', on_error='raise')
+
+    def test_generate_mount_points(self) -> None:
+        def _call_with_type_check(_task: str) -> t.Tuple[t.Dict, t.List, t.Dict]:
+            _mounts, _args, _mounts_opts = Shell.generate_mounts_and_args(_mlcube_config, _task, make_dirs=False)
+
+            self.assertIsInstance(_mounts, dict, "Invalid mounts dictionary")
+            self.assertIsInstance(_args, list, "Invalid args list")
+            self.assertIsInstance(_mounts_opts, dict, "Invalid mounts opts dictionary")
+
+            return _mounts, _args, _mounts_opts
+
+        # Test Case 1
+        mounts, args, mounts_opts = _call_with_type_check('process')
+        self.assertDictEqual(
+            mounts,
+            {
+                '/mlcube/workspace/input': '/mlcube_io0',
+                '/mlcube/workspace/output': '/mlcube_io1'
+            }
+        )
+        self.assertListEqual(args, ['process', '--input_dir=/mlcube_io0', '--output_dir=/mlcube_io1'])
+        self.assertDictEqual(
+            mounts_opts,
+            {'/mlcube/workspace/output': 'rw'}
+        )
+
+        # Test Case 2
+        mounts, args, mounts_opts = _call_with_type_check('split')
+        self.assertDictEqual(
+            mounts,
+            {
+                '/mlcube/workspace/input': '/mlcube_io0',
+                '/mlcube/workspace': '/mlcube_io1',
+                '/datasets/my_split': '/mlcube_io2'
+            }
+        )
+        self.assertListEqual(
+            args,
+            ['split', '--input_dir=/mlcube_io0', '--config=/mlcube_io1/config.yaml', '--output_dir=/mlcube_io2']
+        )
+        self.assertDictEqual(
+            mounts_opts,
+            {'/mlcube/workspace': 'ro', '/datasets/my_split': 'rw'}
+        )
+
+
+_mlcube_config = DictConfig({
+    'runtime': {'workspace': '/mlcube/workspace'},
+    'tasks': {
+        'process': {
+            'parameters': {
+                'inputs': {'input_dir': {'type': 'directory', 'default': 'input'}},
+                'outputs': {'output_dir': {'type': 'directory', 'default': 'output', 'opts': 'rw'}}
+            }
+        },
+        'split': {
+            'parameters': {
+                'inputs': {
+                    'input_dir': {'type': 'directory', 'default': 'input'},
+                    'config': {'type': 'file', 'default': 'config.yaml', 'opts': 'ro'}
+                },
+                'outputs': {
+                    'output_dir': {'type': 'directory', 'default': '/datasets/my_split', 'opts': 'rw'}
+                }
+            }
+        }
+    }
+})

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -186,9 +186,8 @@ class DockerRun(Runner):
         # The 'mounts' dictionary maps host paths to container paths
         try:
             mounts, task_args, mounts_opts = Shell.generate_mounts_and_args(self.mlcube, self.task)
-            if mounts_opts:
-                for key, value in mounts_opts.items():
-                    mounts[key]+=f':{value}'
+            for host_path, mount_type in mounts_opts.items():
+                mounts[host_path] += f':{mount_type}'
         except ConfigurationError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,


### PR DESCRIPTION
- Slightly updating the implementation of the `Shell.generate_mounts_and_args` method, in particular:
  - Changing code that generates container paths to only include `/mlcube_io{M}` paths.
  - More robust processing of mount options that define mount types (ro / rw).
  - Fixing various style warnings.
- Adding unit tests for `Shell.generate_mounts_and_args` method.