### PR TITLE
Removing unnecessary dependency of MLCube runners on `click` library.

### DIFF
--- a/runners/mlcube_docker/mlcube_docker/tests/test_mlcube_docker_cli.py
+++ b/runners/mlcube_docker/mlcube_docker/tests/test_mlcube_docker_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_docker():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_docker/requirements.txt
+++ b/runners/mlcube_docker/requirements.txt
@@ -1,3 +1,2 @@
-click==7.1.2
 mlcube==0.0.8
 omegaconf==2.1.0

--- a/runners/mlcube_gcp/mlcube_gcp/tests/test_get_runner_class.py
+++ b/runners/mlcube_gcp/mlcube_gcp/tests/test_get_runner_class.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from mlcube_gcp import get_runner_class
+from mlcube_gcp.gcp_run import GCPRun
+
+
+class TestGetRunnerClass(TestCase):
+    """This is a placeholder test to pass CI workflows."""
+
+    def test_get_runner_class(self) -> None:
+        self.assertIs(get_runner_class(), GCPRun)

--- a/runners/mlcube_gcp/mlcube_gcp/tests/test_mlcube_gcp_cli.py
+++ b/runners/mlcube_gcp/mlcube_gcp/tests/test_mlcube_gcp_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_docker():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_gcp/requirements.txt
+++ b/runners/mlcube_gcp/requirements.txt
@@ -1,4 +1,3 @@
-click==7.1.2
 mlcube==0.0.8
 google-api-python-client==1.12.5
 ssh-config==0.0.22

--- a/runners/mlcube_k8s/mlcube_k8s/tests/test_get_runner_class.py
+++ b/runners/mlcube_k8s/mlcube_k8s/tests/test_get_runner_class.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from mlcube_k8s import get_runner_class
+from mlcube_k8s.k8s_run import KubernetesRun
+
+
+class TestGetRunnerClass(TestCase):
+    """This is a placeholder test to pass CI workflows."""
+
+    def test_get_runner_class(self) -> None:
+        self.assertIs(get_runner_class(), KubernetesRun)

--- a/runners/mlcube_k8s/mlcube_k8s/tests/test_mlcube_k8s_cli.py
+++ b/runners/mlcube_k8s/mlcube_k8s/tests/test_mlcube_k8s_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_docker():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_k8s/requirements.txt
+++ b/runners/mlcube_k8s/requirements.txt
@@ -1,4 +1,3 @@
-click==7.1.2
 mlcube==0.0.8
 kubernetes==12.0.0
 diagrams==0.17.0

--- a/runners/mlcube_kubeflow/mlcube_kubeflow/tests/test_get_runner_class.py
+++ b/runners/mlcube_kubeflow/mlcube_kubeflow/tests/test_get_runner_class.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from mlcube_kubeflow import get_runner_class
+from mlcube_kubeflow.kubeflow_run import KubeflowRun
+
+
+class TestGetRunnerClass(TestCase):
+    """This is a placeholder test to pass CI workflows."""
+
+    def test_get_runner_class(self) -> None:
+        self.assertIs(get_runner_class(), KubeflowRun)

--- a/runners/mlcube_kubeflow/mlcube_kubeflow/tests/test_mlcube_kubeflow_cli.py
+++ b/runners/mlcube_kubeflow/mlcube_kubeflow/tests/test_mlcube_kubeflow_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_kubeflow():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_mlcommons_box_singularity_cli.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_mlcommons_box_singularity_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_docker():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,3 +1,2 @@
-click==7.1.2
 mlcube==0.0.8
 spython==0.2.1

--- a/runners/mlcube_ssh/mlcube_ssh/tests/test_mlcube_ssh_cli.py
+++ b/runners/mlcube_ssh/mlcube_ssh/tests/test_mlcube_ssh_cli.py
@@ -1,9 +1,0 @@
-from click.testing import CliRunner
-
-
-runner = CliRunner()
-
-
-def test_mlcube_ssh():
-    from mlcube.tests.test_mlcommons_mlcube_cli import test_mlcube
-    test_mlcube()

--- a/runners/mlcube_ssh/requirements.txt
+++ b/runners/mlcube_ssh/requirements.txt
@@ -1,3 +1,2 @@
-click==7.1.2
 mlcube==0.0.8
 omegaconf==2.1.0


### PR DESCRIPTION
MLCube runners are not supposed to be executable. Instead, they are plugins for MLCube CLI that serves as a single entry point to run user ML cubes. In current implementation, runners depend on `click` via providing this dependency in their requirements files, but in fact, they never import and never use it (several unit tests that do import click just call mlcube's tests, what is redundant anyway).