### PR TITLE
Removing redundant python dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools wheel
       - name: Install MLCube
         run: |
           cd mlcube
-          pip install -r requirements.txt
-          python setup.py sdist bdist_wheel
-          pip install dist/mlcube*.whl
+          python setup.py bdist_wheel
+          pip install dist/mlcube-*.whl
       - name: Test MLCube CLI
         run: |
           cd mlcube
@@ -33,8 +33,8 @@ jobs:
       - name: Install MLCube Docker Runner
         run: |
           cd runners/mlcube_docker
-          pip install -r requirements.txt
-          python setup.py sdist bdist_wheel
+          python setup.py bdist_wheel
+          pip install dist/mlcube_docker-*.whl
       - name: Test MLCube Docker CLI
         run: |
           cd runners/mlcube_docker
@@ -42,8 +42,8 @@ jobs:
       - name: Install MLCube Singularity Runner
         run: |
           cd runners/mlcube_singularity
-          pip install -r requirements.txt
-          python setup.py sdist bdist_wheel
+          python setup.py bdist_wheel
+          pip install dist/mlcube_singularity-*.whl
       - name: Test MLCube Singularity CLI
         run: |
           cd runners/mlcube_singularity
@@ -51,8 +51,8 @@ jobs:
       - name: Install MLCube SSH Runner
         run: |
           cd runners/mlcube_ssh
-          pip install -r requirements.txt
-          python setup.py sdist bdist_wheel
+          python setup.py bdist_wheel
+          pip install dist/mlcube_ssh-*.whl
       - name: Test MLCube SSH CLI
         run: |
           cd runners/mlcube_ssh
@@ -60,7 +60,8 @@ jobs:
       - name: Install MLCube Kubernetes Runner
         run: |
           cd runners/mlcube_k8s
-          python setup.py install
+          python setup.py bdist_wheel
+          pip install dist/mlcube_k8s-*.whl
       - name: Test MLCube Kubernetes CLI
         run: |
           cd runners/mlcube_k8s
@@ -68,8 +69,8 @@ jobs:
       - name: Install MLCube GCP Runner
         run: |
           cd runners/mlcube_gcp
-          pip install -r requirements.txt
-          python setup.py sdist bdist_wheel
+          python setup.py bdist_wheel
+          pip install dist/mlcube_gcp-*.whl
       - name: Test MLCube GCP CLI
         run: |
           cd runners/mlcube_gcp
@@ -77,7 +78,8 @@ jobs:
       - name: Install MLCube Kubeflow Runner
         run: |
           cd runners/mlcube_kubeflow
-          python setup.py install
+          python setup.py bdist_wheel
+          pip install dist/mlcube_kubeflow-*.whl
       - name: Test MLCube Kubeflow CLI
         run: |
           cd runners/mlcube_kubeflow

--- a/mlcube/requirements.txt
+++ b/mlcube/requirements.txt
@@ -3,12 +3,8 @@ flake8>=3.7.9, <4.0
 pytest-cov>=2.5, <3.0
 pytest-mock>=1.7.1,<2.0
 pytest>=5.0, <6.0
-wheel==0.32.2
 click==7.1.2
-halo==0.0.30
 coloredlogs==14.0
 cookiecutter==1.7.2
-docker==4.3.1
-PyYAML>=5.4,<6.0
 omegaconf==2.1.0
 markdown


### PR DESCRIPTION
Several python dependencies, such as `docker` and `PyYAML` have been listed as MLCube's dependencies for historical reasons. This commits removes them.