### PR TITLE
Fixes #299 (MLCube doesn't recognize parameter type on Windows)

### DIFF
--- a/mlcube/mlcube/tests/test_config.py
+++ b/mlcube/mlcube/tests/test_config.py
@@ -33,7 +33,7 @@ tasks:
       inputs:
         data_config: {type: file, default: data.yaml}
       outputs:
-        data_dir: {type: directory, default: data}
+        data_dir: data/
         log_dir: {type: directory, default: logs}
   train:
     parameters:
@@ -41,8 +41,8 @@ tasks:
         data_dir: {type: directory, default: data}
         train_config: {type: file, default: train.yaml}
       outputs:
-        log_dir: {type: directory, default: logs}
-        model_dir: {type: directory, default: model}
+        log_dir: logs/
+        model_dir: model\\
 """
 
 _DOWNLOAD_TASK_ENTRY_POINT = '/workspace/mnist/download.py'
@@ -104,7 +104,7 @@ class TestConfig(TestCase):
                         'data_config': {'type': 'file', 'default': 'data.yaml'}
                     },
                     'outputs': {
-                        'data_dir': {'type': 'directory', 'default': 'data'},
+                        'data_dir': {'type': 'directory', 'default': 'data/'},
                         'log_dir': {'type': 'directory', 'default': 'logs'}
                     }
                 },
@@ -116,8 +116,8 @@ class TestConfig(TestCase):
                         'train_config': {'type': 'file', 'default': 'train.yaml'}
                     },
                     'outputs': {
-                        'log_dir': {'type': 'directory', 'default': 'logs'},
-                        'model_dir': {'type': 'directory', 'default': 'model'}
+                        'log_dir': {'type': 'directory', 'default': 'logs/'},
+                        'model_dir': {'type': 'directory', 'default': 'model\\'}
                     }
                 }
             }
@@ -159,6 +159,7 @@ class TestConfig(TestCase):
     def test_create_mlcube_config_entrypoints(self) -> None:
         mlcube: DictConfig = MLCubeConfig.create_mlcube_config("/some/path/to/mlcube.yaml")
         self._check_standard_config(mlcube, entry_points=True)
+
 
     def test_io_type(self) -> None:
         self.assertEqual(IOType.INPUT, 'input')


### PR DESCRIPTION
Users can use slashes (`/` and `\`)  at the end of parameters values to specify that these parameters are directories: `data_dir: data/`.  Another option is to explicitly specify parameter type: `log_dir: {type: directory, default: logs}` MLCube needs parameter types to make sure they are properly mounted inside running containers. Types must be specified for parameters (file system artifacts) that do not exist at the time MLCube runs, and mostly applicable to output parameters. 

The code was using `os.sep` to test the last character when users do not explicitly specify types. This is, however, OS-specific and returns either forward or backward slashes depending on a user OS. So, in Windows, the forward slash was not being recognized as a path separator, and thus the parameter type could be identified automatically in these cases.