### PR TITLE
Commit that fixes a number of bugs.

### DIFF
--- a/mlcube/mlcube/parser.py
+++ b/mlcube/mlcube/parser.py
@@ -5,7 +5,6 @@
 - `CliParser`: Helper utilities to parse command linea arguments.
 """
 import abc
-from ast import Pass
 import os
 import typing as t
 
@@ -78,70 +77,65 @@ class CliParser(object):
         return arg.split(",")
 
     @staticmethod
-    def parse_extra_arg(*args: str) -> t.Tuple[DictConfig, t.Dict]:
+    def parse_extra_arg(
+            unparsed_args: t.List[str], parsed_args: t.Dict[str, t.Optional[str]]
+    ) -> t.Tuple[DictConfig, t.Dict]:
         """Parse extra arguments on a command line.
 
         These arguments correspond to:
             - MLCube runtime arguments. These start with `-P` prefix and are translated to a nested dictionaries
                 structure using `.` as a separator. For instance, `-Pdocker.image=mlcommons/mnist:0.0.1` translates to
                 python dictionary {'docker': {'image': 'mlcommons/mnist:0.0.1'}}.
-            - Task arguments are all other arguments that do not star with `-P`. These arguments are input/output
-                arguments of tasks.
+            - Task arguments are all other arguments that do not star with `-P` or `--`. These arguments are
+                input/output arguments of tasks.
+
         Args:
-            args: List of arguments that have not been parsed before.
+            unparsed_args: List of arguments that have not been parsed yet. These are parameters that are described
+                above (MLCube runtime arguments and task arguments).
+            parsed_args: CLI arguments that have already been parsed. These are all other CLI arguments that start with
+                `--` prefix, and are normally parsed by libraries such as `click` or `argparse`. This dictionary will
+                 also include such arguments as `--platform`, `--mlcube` and others. Keys in this dictionary are
+                 argument names without `--` prefix. The following is the list of arguments this function can parse:
+                    - `platform`: Platform to use to run this MLCube (docker, singularity, gcp, k8s etc).
+                    - `network_option`: Networking options defined during MLCube container execution.
+                    - `security_option`: Security options defined during MLCube container execution.
+                    - `gpus_option`: GPU usage options defined during MLCube container execution.
+                    - `memory_option`: Memory RAM options defined during MLCube container execution.
+                    - `cpu_option`: CPU options defined during MLCube container execution.
+
         Returns:
             Tuple of two dictionaries: (mlcube_arguments, task_arguments).
         """
+        # Parse unparsed arguments
         mlcube_args = OmegaConf.from_dotlist(
-            [arg[2:] for arg in args if arg.startswith("-P")]
+            [arg[2:] for arg in unparsed_args if arg.startswith("-P")]
         )
 
-        task_args = [arg.split("=") for arg in args if not arg.startswith("-P")]
+        task_args = [arg.split("=") for arg in unparsed_args if not arg.startswith("-P")]
         task_args = {arg[0]: arg[1] for arg in task_args}
 
+        # Parse unparsed arguments
+        platform: t.Optional[str] = parsed_args.get('platform', None)
+        if platform in {'docker', 'singularity'}:
+            runner_run_args = {}
+            if parsed_args.get('network', None):
+                runner_run_args["--network"] = parsed_args['network']
+            if parsed_args.get('security', None):
+                key = "--security-opt" if platform == "docker" else "--security"
+                runner_run_args[key] = parsed_args['security']
+            if parsed_args.get('gpus', None):
+                if platform == "docker":
+                    runner_run_args["--gpus"] = parsed_args['gpus']
+                else:
+                    runner_run_args["--nv"] = ""
+                    os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES'] = parsed_args['gpus']
+            if parsed_args.get('memory', None):
+                key = "--memory" if platform == "docker" else "--vm-ram"
+                runner_run_args[key] = parsed_args['memory']
+            if parsed_args.get('cpu', None):
+                key = "--cpuset-cpus" if platform == "docker" else "--vm-cpu"
+                runner_run_args[key] = parsed_args['cpu']
+
+            mlcube_args.merge_with({platform: runner_run_args})
+
         return mlcube_args, task_args
-
-    @staticmethod
-    def parse_optional_arg(
-        platform: t.Optional[str],
-        network_option: t.Optional[str],
-        security_option: t.Optional[str],
-        gpus_option: t.Optional[str],
-        memory_option: t.Optional[str],
-        cpu_option: t.Optional[str],
-    ) -> t.Tuple[DictConfig, t.Dict]:
-        """platform: Platform to use to run this MLCube (docker, singularity, gcp, k8s etc).
-        network_option: Networking options defined during MLCube container execution.
-        security_option: Security options defined during MLCube container execution.
-        gpus_option: GPU usage options defined during MLCube container execution.
-        memory_option: Memory RAM options defined during MLCube container execution.
-        cpu_option: CPU options defined during MLCube container execution.
-        """
-        mlcube_args, opts = {}, {}
-
-        if network_option is not None:
-            opts["--network"] = network_option
-
-        if security_option is not None:
-            key = "--security-opt" if platform == "docker" else "--security"
-            opts[key] = security_option
-
-        if gpus_option is not None:
-            if platform == "docker":
-                key = "--gpus" 
-            else:
-                key = "--nv"
-                os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES'] = gpus_option
-                gpus_option = ""
-            opts[key] = gpus_option
-
-        if memory_option is not None:
-            key = "--memory" if platform == "docker" else "--vm-ram"
-            opts[key] = memory_option
-
-        if cpu_option is not None:
-            key = "--cpuset-cpus" if platform == "docker" else "--vm-cpu"
-            opts[key] = cpu_option
-
-        mlcube_args[platform] = opts
-        return mlcube_args, {}

--- a/mlcube/mlcube/tests/test_cli.py
+++ b/mlcube/mlcube/tests/test_cli.py
@@ -1,9 +1,11 @@
 import typing as t
 from unittest import TestCase
 
-from click import Option
+from click import Option, BaseCommand
+from click.testing import CliRunner, Result
 
 from mlcube.cli import (markdown2text, Options)
+from mlcube.__main__ import cli, show_config, configure, run, describe, config, create
 
 
 class TestCli(TestCase):
@@ -34,3 +36,13 @@ class TestCli(TestCase):
         self.assertEqual(
             8, len(decorators), f"Expected number of option decorators is 8. Actual tested decorators: {decorators}."
         )
+
+    def test_help(self) -> None:
+        """python -m unittest  mlcube.tests.test_cli"""
+        cli_funcs = [
+            cli, show_config, configure, run, describe, config, create
+        ]
+        for cli_func in cli_funcs:
+            self.assertIsInstance(cli_func, BaseCommand)
+            result: Result = CliRunner().invoke(cli_func, [f"--help"])
+            self.assertEqual(result.exit_code, 0, f"Error while running `{cli_func.name}`. Output: {result.output}")

--- a/mlcube/mlcube/tests/test_parser.py
+++ b/mlcube/mlcube/tests/test_parser.py
@@ -1,11 +1,40 @@
+import os
+import typing as t
 from unittest import TestCase
 
-from mlcube.parser import CliParser
+from mlcube.parser import CliParser, MLCubeDirectory
 
 from omegaconf import (DictConfig, OmegaConf)
 
 
 class TestParser(TestCase):
+    def setUp(self) -> None:
+        if 'SINGULARITYENV_CUDA_VISIBLE_DEVICES' in os.environ:
+            self._singularityenv_cuda_visible_devices = os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES']
+
+    def tearDown(self) -> None:
+        if hasattr(self, '_singularityenv_cuda_visible_devices'):
+            os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES'] = self._singularityenv_cuda_visible_devices
+        elif 'SINGULARITYENV_CUDA_VISIBLE_DEVICES' in os.environ:
+            del os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES']
+
+    def _check_mlcube_directory(self, mlcube: MLCubeDirectory, path: str, file: str) -> None:
+        self.assertIsInstance(mlcube, MLCubeDirectory)
+        self.assertEqual(mlcube.path, path)
+        self.assertEqual(mlcube.file, file)
+
+    def test_mlcube_instances(self) -> None:
+        self._check_mlcube_directory(MLCubeDirectory(), os.getcwd(), "mlcube.yaml")
+        self._check_mlcube_directory(MLCubeDirectory(os.getcwd()), os.getcwd(), "mlcube.yaml")
+
+    def test_cli_parser(self) -> None:
+        for method_name in ("parse_mlcube_arg", "parse_list_arg", "parse_extra_arg"):
+            self.assertTrue(getattr(CliParser, method_name))
+
+    def test_parse_mlcube_arg(self) -> None:
+        self._check_mlcube_directory(CliParser.parse_mlcube_arg(os.getcwd()), os.getcwd(), "mlcube.yaml")
+        self._check_mlcube_directory(CliParser.parse_mlcube_arg(None), os.getcwd(), "mlcube.yaml")
+
     def test_parse_list_arg(self) -> None:
         for arg in ("", None):
             self.assertListEqual(CliParser.parse_list_arg(arg, 'main'), ['main'])
@@ -13,21 +42,78 @@ class TestParser(TestCase):
         self.assertListEqual(CliParser.parse_list_arg('download'), ['download'])
         self.assertListEqual(CliParser.parse_list_arg('download,train'), ['download', 'train'])
 
-    def test_parse_extra_args(self) -> None:
+    def _check_cli_args(
+            self,
+            actual_mlcube_args: DictConfig, actual_task_args: t.Dict,
+            expected_mlcube_args: t.Dict, expected_task_args: t.Dict
+    ) -> None:
+        self.assertIsInstance(actual_mlcube_args, DictConfig)
+        self.assertEqual(OmegaConf.to_container(actual_mlcube_args), expected_mlcube_args)
+
+        self.assertIsInstance(actual_task_args, dict)
+        self.assertEqual(actual_task_args, expected_task_args)
+
+    def test_parse_extra_args_unparsed(self) -> None:
         mlcube_args, task_args = CliParser.parse_extra_arg(
-            "-Pdocker.image=IMAGE_NAME",
-            "data_config=/configs/data.yaml",
-            "-Pplatform.host_memory_gb=30",
-            "data_dir=/data/imagenet"
+            unparsed_args=[
+                "-Pdocker.image=IMAGE_NAME",
+                "data_config=/configs/data.yaml",
+                "-Pplatform.host_memory_gb=30",
+                "data_dir=/data/imagenet"
+            ],
+            parsed_args={}
         )
-        self.assertIsInstance(mlcube_args, DictConfig)
-        self.assertEqual(
-            OmegaConf.to_container(mlcube_args),
-            {'docker': {'image': 'IMAGE_NAME'}, 'platform': {'host_memory_gb': 30}}
+        self._check_cli_args(
+            actual_mlcube_args=mlcube_args,
+            actual_task_args=task_args,
+            expected_mlcube_args={'docker': {'image': 'IMAGE_NAME'}, 'platform': {'host_memory_gb': 30}},
+            expected_task_args={'data_config': '/configs/data.yaml', 'data_dir': '/data/imagenet'}
         )
 
-        self.assertIsInstance(task_args, dict)
-        self.assertEqual(
-            task_args,
-            {'data_config': '/configs/data.yaml', 'data_dir': '/data/imagenet'}
+    def test_parse_extra_args_parsed_docker(self) -> None:
+        mlcube_args, task_args = CliParser.parse_extra_arg(
+            unparsed_args=[],
+            parsed_args={
+                "platform": "docker",
+                "network": "NETWORK_1", "security": "SECURITY_1", "gpus": "GPUS_1", "memory": "MEMORY_1", "cpu": "CPU_1"
+            }
         )
+        self._check_cli_args(
+            actual_mlcube_args=mlcube_args,
+            actual_task_args=task_args,
+            expected_mlcube_args={
+                'docker': {
+                    '--network': 'NETWORK_1',
+                    '--security-opt': 'SECURITY_1',
+                    '--gpus': 'GPUS_1',
+                    '--memory': 'MEMORY_1',
+                    '--cpuset-cpus': 'CPU_1'
+                }
+            },
+            expected_task_args={}
+        )
+
+    def test_parse_extra_args_parsed_singularity(self) -> None:
+        mlcube_args, task_args = CliParser.parse_extra_arg(
+            unparsed_args=[],
+            parsed_args={
+                "platform": "singularity",
+                "network": "NETWORK_2", "security": "SECURITY_2", "gpus": "GPUS_2", "memory": "MEMORY_2", "cpu": "CPU_2"
+            }
+        )
+        self._check_cli_args(
+            actual_mlcube_args=mlcube_args,
+            actual_task_args=task_args,
+            expected_mlcube_args={
+                'singularity': {
+                    '--network': 'NETWORK_2',
+                    '--security': 'SECURITY_2',
+                    '--nv': '',
+                    '--vm-ram': 'MEMORY_2',
+                    '--vm-cpu': 'CPU_2'
+                }
+            },
+            expected_task_args={}
+        )
+        self.assertIn('SINGULARITYENV_CUDA_VISIBLE_DEVICES', os.environ)
+        self.assertEqual(os.environ['SINGULARITYENV_CUDA_VISIBLE_DEVICES'], 'GPUS_2')

--- a/runners/mlcube_docker/mlcube_docker/docker_run.py
+++ b/runners/mlcube_docker/mlcube_docker/docker_run.py
@@ -76,14 +76,13 @@ class Config(RunnerConfig):
             #   'pull': never try to build, always pull
             #   'auto': build if image not found and dockerfile found
             #   'always': build even if image found
-            "--network": "",  # Networking options defined during MLCube container execution.
-            "--security-opt": "",  # Security options for Docker.
-            "--gpus": "",  # GPU usage options defined during MLCube container execution.
-            "--nv": "",  # GPU usage options for Singularity.
-            "--memory": "",  # RAM options defined during MLCube container execution.
-            "--cpuset-cpus": "",  # CPU cores options for Docker.
             # TODO: The above variable may be confusing. Is `configure_strategy` better? Docker uses `--pull`
             #       switch as build arg to force pulling the base image.
+            "--network": None,  # Networking options defined during MLCube container execution.
+            "--security-opt": None,  # Security options for Docker.
+            "--gpus": None,  # GPU usage options defined during MLCube container execution.
+            "--memory": None,  # RAM options defined during MLCube container execution.
+            "--cpuset-cpus": None,  # CPU cores options for Docker.
         }
     )
 
@@ -248,12 +247,13 @@ class DockerRun(Runner):
         run_args: t.Text = self.mlcube.runner.cpu_args if num_gpus == 0 else self.mlcube.runner.gpu_args
 
         extra_args_list = [
-            f"{key}={self.mlcube.runner[key]}"
-            for key in self.mlcube.runner.keys()
-            if "--" in key and self.mlcube.runner[key] != ""
+            f"{key}={value}"
+            for key, value in self.mlcube.runner.items()
+            if key.startswith('--') and value is not None
         ]
-        extra_args = " ".join([str(element) for element in extra_args_list])
-        run_args += extra_args
+        extra_args = " ".join(extra_args_list)
+        if extra_args:
+            run_args += " " + extra_args
 
         if "entrypoint" in self.mlcube.tasks[self.task]:
             logger.info(
@@ -263,7 +263,7 @@ class DockerRun(Runner):
             )
             # If entrypoints contain whitespaces e.g. "python /workspace/download.py"
             # pass only the first token (e.g. python) to --entrypoint
-            # the remaining aruguments are specified after the container_image_name, as shown here:
+            # the remaining arguments are specified after the container_image_name, as shown here:
             # "docker run --entrypoint [new_command] [container_image_name] [optional_arguments_for_entrypoint]"
 
             if len(shlex.split(self.mlcube.tasks[self.task].entrypoint)) > 1:
@@ -282,7 +282,8 @@ class DockerRun(Runner):
                     )
 
                 # use first item in entry point list as the executable to specify in docker run --entrypoint
-                # specify the arguments to the new entrypoint executable immediatly after the container_image_name in the docker run command
+                # specify the arguments to the new entrypoint executable immediatly after the container_image_name
+                # in the docker run command
                 run_args += f" --entrypoint={shlex.split(self.mlcube.tasks[self.task].entrypoint)[0]}"
 
             else:


### PR DESCRIPTION
- Adding missing help option for the `run` command.
- Refactoring `parse_cli_args` function. Instead of many CLI parameters, it accepts two - parsed and unparsed arguments. Parsed arguments are those parsed by tools such as `click` or `argparse`. Unparsed arguments represent mlcube or task arguments.
- Removing some unused imports.
- Removing `CliParsed.parse_optional_arg` method. Its functionality has been merged into `CliParser.parse_extra_arg` method.
- Adding more unit tests for MLCube CLI interface and `mlcube.parser` module.
- Updating default values for new Docker and Singularity runners parameters (those that start with `--`). Default value is None now.
- Docker runner was correctly processing new parameters (those starting with `--`) - it was ignoring empty values. Singularity runner did not check if parameters were not provided. This commit also fixes this.