### PR TITLE
Singularity client.

### DIFF
--- a/mlcube/mlcube/__main__.py
+++ b/mlcube/mlcube/__main__.py
@@ -136,7 +136,8 @@ def cli(log_level: t.Optional[str]):
         log_level = log_level.upper()
         logging.basicConfig(level=log_level)
         coloredlogs.install(level=log_level)
-        logging.info("Setting Log Level from CLI argument to '%s'.", log_level)
+        logging.info("cli setting log Level from CLI argument to '%s'.", log_level)
+    logger.debug("cli command=%s", sys.argv)
     _ = SystemSettings().update_installed_runners()
 
 
@@ -269,6 +270,10 @@ def run(
         memory: Memory RAM options defined during MLCube container execution.
         cpu: CPU options defined during MLCube container execution.
     """
+    logger.info(
+        "run input_arg mlcube=%s, platform=%s, task=%s, workspace=%s, network=%s, security=%s, gpus=%s, memory=%s, "
+        "cpu=%s", mlcube, platform, task, workspace, network, security, gpus, memory, cpu
+    )
     runner_cls, mlcube_config = parse_cli_args(
         unparsed_args=ctx.args,
         parsed_args={
@@ -315,12 +320,12 @@ def run(
     try:
         # TODO: Sergey - Can we have one instance for all tasks?
         for task in tasks:
-            logger.info("Task = %s", task)
+            logger.info("run task = %s", task)
             runner = runner_cls(mlcube_config, task=task)
             runner.run()
     except MLCubeError as err:
         exit_code = err.context.get("code", 1) if isinstance(err, ExecutionError) else 1
-        logger.exception(f"Failed to run MLCube with error code {exit_code}.")
+        logger.exception(f"run failed to run MLCube with error code {exit_code}.")
         if isinstance(err, ExecutionError):
             print(err.describe())
         sys.exit(exit_code)

--- a/mlcube/mlcube/config.py
+++ b/mlcube/mlcube/config.py
@@ -114,17 +114,17 @@ class MLCubeConfig(object):
                 not present in system settings (e.g., outdated version)and to validate to overall configuration.
                 TODO: This class should also be used to do runner-specific parsing of input parameters.
         """
+        logger.debug(
+            "MLCubeConfig.create_mlcube_config input_arg mlcube_config_file=%s, mlcube_cli_args=%s, task_cli_args=%s, "
+            "runner_config=%s, workspace=%s",
+            mlcube_config_file, mlcube_cli_args, task_cli_args, runner_config, workspace
+        )
         if mlcube_cli_args is None:
             mlcube_cli_args = OmegaConf.create({})
         if task_cli_args is None:
             task_cli_args = {}
         if runner_config is None:
             runner_config = OmegaConf.create({})
-        logger.debug("mlcube_config_file = %s", mlcube_config_file)
-        logger.debug("mlcube_cli_args = %s", mlcube_cli_args)
-        logger.debug("task_cli_args = %s", task_cli_args)
-        logger.debug("runner_config = %s", str(runner_config))
-        logger.debug("workspace = %s", workspace)
 
         # Load MLCube configuration and maybe override parameters from command line (like -Pdocker.build_strategy=...).
         actual_workspace = '${runtime.root}/workspace' if workspace is None else MLCubeConfig.get_uri(workspace)

--- a/mlcube/mlcube/platform.py
+++ b/mlcube/mlcube/platform.py
@@ -53,8 +53,8 @@ class Platform(object):
                 get_runner_class: t.Optional[t.Callable] = getattr(module, 'get_runner_class', None)
                 if get_runner_class is None:
                     logger.warning(
-                        "Candidate MLCube runner package (%s) does not provide runner class "
-                        "function (get_runner_class).", pkg_name
+                        "Platform.get_installed_runners candidate MLCube runner package (%s) does not provide runner "
+                        "class function (get_runner_class).", pkg_name
                     )
                     continue
                 runner_cls: t.Type[Runner] = get_runner_class()
@@ -62,9 +62,15 @@ class Platform(object):
                     raise TypeError(f"Invalid type of a runner ({runner_cls}). Expecting subclass of {Runner}.")
                 runner_name = runner_cls.CONFIG.DEFAULT.runner
                 installed_runners[runner_name] = {'config': {'pkg': pkg_name}, 'runner_cls': runner_cls}
-                logger.info("Found installed MLCube runner: platform=%s, pkg=%s", runner_name, pkg_name)
+                logger.info(
+                    "Platform.get_installed_runners found installed MLCube runner: platform=%s, pkg=%s",
+                    runner_name, pkg_name
+                )
             except (AttributeError, TypeError) as e:
-                logger.warning("Package (%s) is not a valid MLCube runner. Error = \"%s\"", pkg_name, str(e))
+                logger.warning(
+                    "Platform.get_installed_runners package (%s) is not a valid MLCube runner. Error=\"%s\"",
+                    pkg_name, str(e)
+                )
         return installed_runners
 
     @staticmethod

--- a/mlcube/mlcube/runner.py
+++ b/mlcube/mlcube/runner.py
@@ -77,7 +77,7 @@ class Runner(object):
         self.mlcube = mlcube
         self.task = task
 
-        logger.debug("%s configuration: %s", self.__class__.__name__, str(self.mlcube.runner))
+        logger.debug("%s.__init__ configuration: %s", self.__class__.__name__, str(self.mlcube.runner))
 
     def configure(self) -> None:
         """Configure this MLCube."""

--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -117,6 +117,8 @@ class Shell(object):
         try:
             exit_code = 0
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
+        except FileNotFoundError as err:
+            exit_code, output = 1, str(err)
         except subprocess.CalledProcessError as err:
             exit_code, output = err.returncode, err.output.decode()
 

--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -74,8 +74,10 @@ class Shell(object):
             Exit status. On Windows, the exit status is the output of `os.system`. On Linux, the output is either
                 process exit status if that processes exited, or -1 in other cases (e.g., process was killed).
         """
+        logger.debug("Shell.run input_arg: cmd=%s, on_error=%s)", cmd, on_error)
         if isinstance(cmd, t.List):
-            cmd = ' '.join(cmd)
+            cmd = ' '.join(c for c in (c.strip() for c in cmd) if c)
+            logger.debug("Shell.run list->str: cmd=\"%s\")", cmd)
 
         if on_error not in ('raise', 'die', 'ignore'):
             raise ValueError(
@@ -85,9 +87,10 @@ class Shell(object):
         status: int = os.system(cmd)
         exit_code, exit_status = Shell.parse_exec_status(status)
         if exit_status == 'na':
-            logger.warning("Command (cmd=%s) did not exit properly (status=%d).", cmd, status)
+            logger.warning("Shell.run command (cmd=%s) did not exit properly (status=%d).", cmd, status)
 
-        msg = f"Command='{cmd}' status={status} exit_status={exit_status} exit_code={exit_code} on_error={on_error}"
+        msg = f"Shell.run command='{cmd}' status={status} exit_status={exit_status} exit_code={exit_code} "\
+              f"on_error={on_error}"
         if exit_code != 0:
             logger.error(msg)
             if on_error == 'die':
@@ -112,11 +115,15 @@ class Shell(object):
              which is either output of `subprocess.check_output` or `subprocess.CalledProcessError.output.decode()`.
         """
         try:
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
             exit_code = 0
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
         except subprocess.CalledProcessError as err:
-            output = err.output.decode()
-            exit_code = err.returncode
+            exit_code, output = err.returncode, err.output.decode()
+
+        logger.debug(
+            "Shell.run_and_capture_output cmd=%s, exit_code=%d, output=\"%s\"",
+            cmd, exit_code, output.replace("\n", " ")
+        )
         return exit_code, output.strip()
 
     @staticmethod

--- a/mlcube/mlcube/system_settings.py
+++ b/mlcube/mlcube/system_settings.py
@@ -64,10 +64,12 @@ class SystemSettings(object):
         """
         self.path: Path = Path(path if path is not None else SystemSettings.system_settings_file()).resolve()
         if not self.path.exists():
-            logger.info("MLCube system settings file does not exist (%s).", str(self.path))
+            logger.info(
+                "SystemSettings.__init__ MLCube system settings file does not exist (%s).", self.path.as_posix()
+            )
             self.path.touch()
         else:
-            logger.info("MLCube system settings file exists (%s)", str(self.path))
+            logger.info("SystemSettings.__init__ MLCube system settings file exists (%s)", self.path.as_posix())
         self.settings: DictConfig = OmegaConf.load(self.path)
         if not isinstance(self.settings, DictConfig):
             raise ValueError(f"Invalid object read from {self.path} (type = {type(self.settings)}). "

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 # Development dependencies for MLCube and all MLCube runners.
-black==v19.10b0
+black==23.7.0
 flake8>=3.7.9, <4.0
 isort

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
@@ -1,0 +1,224 @@
+import logging
+import typing as t
+from enum import Enum
+from pathlib import Path
+
+import semver
+
+from mlcube.errors import ExecutionError
+from mlcube.shell import Shell
+from mlcube.system_settings import SystemSettings
+
+__all__ = ["Runtime", "Version", "Client"]
+
+logger = logging.getLogger(__name__)
+
+
+class Runtime(Enum):
+    """Container runtime"""
+
+    UNKNOWN = 0
+    APPTAINER = 1
+    SINGULARITY = 2
+
+
+class Version:
+    def __init__(self, runtime: Runtime, version: semver.VersionInfo) -> None:
+        self.runtime = runtime
+        self.version = version
+
+    def __str__(self) -> str:
+        return f"Version(runtime={self.runtime.name}, version={self.version})"
+
+
+class Client:
+    """Singularity container platform client.
+
+    Args:
+        singularity: A shell command to run singularity. When it's string, it needs to be constructed so that splitting
+        using space character resulted in correct sequence of commands and arguments.
+    """
+
+    @classmethod
+    def from_env(cls) -> "Client":
+        # Check if system settings file contains information about singularity.
+        executables = ["singularity", "sudo singularity", "apptainer", "sudo apptainer"]
+
+        system_settings = SystemSettings()
+        if "singularity" in system_settings.platforms:
+            executables = [
+                system_settings.platforms["singularity"]["singularity"]
+            ] + executables
+            logger.info(
+                "Client.from_env found singularity platform config in MLCube system settings file "
+                "(file=%s, platform=%s). Will try it first for detecting singularity CLI client.",
+                system_settings.path.as_posix(),
+                system_settings.platforms["singularity"],
+            )
+        logger.debug(
+            "Client.from_env will try candidate executables in the following order "
+            "(first available will be selected): %s",
+            executables,
+        )
+
+        for executable in executables:
+            try:
+                client = Client(executable)
+                logger.info(
+                    "Client.from_env found singularity (exec=%s, version=%s)",
+                    client.singularity,
+                    client.version,
+                )
+                return client
+            except ExecutionError:
+                logger.warning(
+                    "Client.from_env failed to run singularity as: %s", executable
+                )
+                continue
+
+        raise ExecutionError(
+            f"Failed to identify proper singularity client. I tried the following: {executables}."
+        )
+
+    def supports_fakeroot(self) -> bool:
+        singularity_35 = (
+            self.version.runtime == Runtime.SINGULARITY
+            and self.version >= semver.VersionInfo(major=3, minor=5)
+        )
+        apptainer = self.version.runtime == Runtime.APPTAINER
+        return singularity_35 or apptainer
+
+    def __init__(self, singularity: t.Union[str, t.List]) -> None:
+        if isinstance(singularity, str):
+            singularity = singularity.split(" ")
+        self.singularity: t.List[str] = [c.strip() for c in singularity if c.strip()]
+        self.version: t.Optional[Version] = None
+        self.init()
+        logger.debug(
+            "Client.__init__ executable=%s, version=%s", self.singularity, self.version
+        )
+
+    def init(self, force: bool = False) -> None:
+        if force:
+            self.version = None
+        if self.version is None:
+            version_cmd = self.singularity + ["--version"]
+            exit_code, version_string = Shell.run_and_capture_output(version_cmd)
+            if exit_code != 0:
+                raise ExecutionError(
+                    f"Singularity client failed to initialize. The following command ({version_cmd}) returned non-zero"
+                    f"exit code ({exit_code}). MLCube cannot run singularity images unless this check passes.",
+                    function=f"{self.__class__}.init",
+                    args={
+                        "force": force,
+                        "singularity": self.singularity,
+                        "version_cmd": version_cmd,
+                    },
+                )
+
+            if version_string.startswith("singularity version "):
+                runtime, version_string = (
+                    Runtime.SINGULARITY,
+                    version_string[20:].strip(),
+                )
+            elif version_string.startswith("apptainer version "):
+                runtime, version_string = Runtime.APPTAINER, version_string[18:].strip()
+            elif "/" in version_string:  # Handle old stuff like "x.y.z-pull/123-0a5d"
+                runtime, version_string = Runtime.SINGULARITY, version_string.replace(
+                    "/", "+", 1
+                )
+            else:
+                logger.warning(
+                    "Client.init unrecognized container runtime (version_string: %s)",
+                    version_string,
+                )
+                runtime = Runtime.UNKNOWN
+            self.version = Version(runtime, semver.VersionInfo.parse(version_string))
+            logger.debug("Client.init version=%s", self.version)
+
+    def build(
+        self,
+        build_dir: str,
+        recipe: str,
+        image_dir: str,
+        image_name: str,
+        build_args: str,
+    ) -> None:
+        # Get full path to a singularity image. By design, we compute it relative to {mlcube.root}/workspace.
+        image_file = Path(image_dir, image_name)
+        if image_file.exists():
+            logger.info(
+                "Client.build won't build SIF image (file exists: %s).",
+                image_file,
+            )
+            return
+
+        # Make sure a directory to store image exists. If paths are like "/opt/...", the call may fail.
+        image_file.parent.mkdir(parents=True, exist_ok=True)
+
+        build_dir = Path(
+            build_dir
+        )  # Let's assume that build context is the root MLCube directory
+        if recipe.startswith("docker://") or recipe.startswith("docker-archive:"):
+            # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
+            # URI beginning with docker:// to build from Docker Hub
+            logger.info(
+                "Client.build will build SIF image from docker image (image=%s).",
+                recipe,
+            )
+        else:
+            # This must be a recipe file. Make sure it exists.
+            if not Path(build_dir, recipe).exists():
+                raise IOError(
+                    f"SIF recipe file does not exist (path={build_dir}, file={recipe})"
+                )
+            logger.info(
+                "Client.build will build SIF image from recipe file (path=%s, file=%s).",
+                build_dir,
+                recipe,
+            )
+        try:
+            Shell.run(
+                ["cd", str(build_dir), ";"]
+                + self.singularity
+                + ["build", build_args, str(image_file), recipe]
+            )
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_configure_error(
+                self.__class__.__name__,
+                "Error occurred while building SIF image. See context for more details.",
+                **err.context,
+            )
+
+    def run(
+        self,
+        run_args: str,
+        volumes: str,
+        image_file: str,
+        args: t.List,
+        entrypoint: t.Optional[str] = None,
+    ) -> None:
+        try:
+            if entrypoint:
+                Shell.run(
+                    self.singularity
+                    + [
+                        "exec",
+                        run_args,
+                        volumes,
+                        image_file,
+                        entrypoint,
+                        " ".join(args),
+                    ]
+                )
+            else:
+                Shell.run(
+                    self.singularity
+                    + ["run", run_args, volumes, image_file, " ".join(args)]
+                )
+        except ExecutionError as err:
+            raise ExecutionError.mlcube_run_error(
+                self.__class__.__name__,
+                f"Error occurred while running MLCube task. See context for more details.",
+                **err.context,
+            )

--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -1,20 +1,16 @@
 import logging
 import typing as t
 from pathlib import Path
-from omegaconf import DictConfig, OmegaConf
-import semver
-from spython.utils.terminal import (
-    get_singularity_version_info,
-    check_install as check_singularity_installed,
-)
-from mlcube.errors import (ConfigurationError, ExecutionError)
-from mlcube.shell import Shell
-from mlcube.runner import Runner, RunnerConfig
 
+from mlcube_singularity.singularity_client import Client
+from omegaconf import DictConfig, OmegaConf
+
+from mlcube.errors import ConfigurationError, ExecutionError
+from mlcube.runner import Runner, RunnerConfig
+from mlcube.shell import Shell
+from mlcube.validate import Validate
 
 __all__ = ["Config", "SingularityRun"]
-
-from mlcube.validate import Validate
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +33,7 @@ class Config(RunnerConfig):
             "--security": None,  # Security options defined during MLCube container execution.
             "--nv": None,  # usage options defined during MLCube container execution.
             "--vm-ram": None,  # RAM options defined during MLCube container execution.
-            "--vm-cpu": None  # CPU options defined during MLCube container execution.
+            "--vm-cpu": None,  # CPU options defined during MLCube container execution.
         }
     )
 
@@ -55,8 +51,8 @@ class Config(RunnerConfig):
         """
         # The `runner` section will contain effective runner configuration. At this point, it may contain configuration
         # from system settings file.
-        if 'runner' not in mlcube:
-            mlcube['runner'] = {}
+        if "runner" not in mlcube:
+            mlcube["runner"] = {}
 
         # We need to merge with the user-provided configuration.
         s_cfg: t.Optional[DictConfig] = mlcube.get("singularity", None)
@@ -64,14 +60,14 @@ class Config(RunnerConfig):
             # Singularity runner will try to use docker section. At this point, it will work as long as we assume we
             # pull docker images from a docker hub.
             logger.warning(
-                "SingularityRun singularity configuration not found in MLCube file (singularity=%s).",
+                "Config.merge singularity configuration not found in MLCube file (singularity=%s).",
                 str(s_cfg),
             )
 
             d_cfg = mlcube.get("docker", None)
             if not d_cfg:
                 logger.warning(
-                    "SingularityRun docker configuration not found too. Singularity runner will likely "
+                    "Config.merge docker configuration not found too. Singularity runner will likely "
                     "fail to run."
                 )
                 return
@@ -80,26 +76,20 @@ class Config(RunnerConfig):
             # generating an image name in a local environment. Key here is that the source has a scheme - `docker://`
             # The --fakeroot switch is useful and is supported in singularity version >= 3.5
             build_args = ""
-            # There's no `singularity` section, so we do not know what singularity executable to use. Let's assume
+            # There's no `singularity` section, so we do not know what singularity executable to use. Several options
+            # that we have: look at system settings file, check for singularity, check for apptainer, check for
+            # sudo singularity, check for sudo apptainer.
+            # Let's assume
             # it's just `singularity`.
-            singularity = "singularity"
-            try:
-                SingularityRun.check_install(singularity)
-                version: semver.VersionInfo = get_singularity_version_info()
-                logger.info("SingularityRun singularity version %s", str(version))
-                if version >= semver.VersionInfo(major=3, minor=5):
-                    logger.info(
-                        "SingularityRun will use --fakeroot CLI switch (version >= 3.5)."
-                    )
-                    build_args = "--fakeroot"
-                else:
-                    logger.warning(
-                        "SingularityRun will not use --fakeroot CLI switch (version < 3.5)"
-                    )
-            except Exception as err:
+            client = Client.from_env()
+            if client.supports_fakeroot():
+                logger.info(
+                    "Config.merge will use --fakeroot CLI switch (CLI client seems to be supporting it)."
+                )
+                build_args = "--fakeroot"
+            else:
                 logger.warning(
-                    "SingularityRun can't get singularity version (do you have singularity installed?). "
-                    "Source=Config.merge. Exception=%s", str(err), exc_info=True
+                    "Config.merge will not use --fakeroot CLI switch (CLI client too old or version unknown)"
                 )
 
             build_file = "docker://" + d_cfg["image"]
@@ -112,11 +102,11 @@ class Config(RunnerConfig):
                     build_file=build_file,
                     build_args=build_args,
                     run_args=run_args,
-                    singularity=singularity,
+                    singularity=" ".join(client.singularity),
                 )
             )
             logger.info(
-                f"SingularityRun singularity runner has converted docker configuration to singularity (%s).",
+                f"Config.merge singularity runner has converted docker configuration to singularity (%s).",
                 str(OmegaConf.to_container(s_cfg)),
             )
 
@@ -131,118 +121,51 @@ class Config(RunnerConfig):
 
 
 class SingularityRun(Runner):
-
     CONFIG = Config
-
-    @staticmethod
-    def check_install(singularity_exec: str = "singularity") -> None:
-        if not check_singularity_installed(software=singularity_exec):
-            raise ExecutionError(
-                f"{SingularityRun.__name__} runner failed to configure or to run MLCube.",
-                "SingularityRun check_install returned false ('singularity --version' failed to run). MLCube cannot "
-                "run singularity images unless this check passes. Singularity runner uses `check_install` function "
-                "from singularity-cli python library (https://github.com/singularityhub/singularity-cli).",
-                function='check_singularity_installed',
-                args={'software': singularity_exec}
-            )
 
     def _get_extra_args(self) -> str:
         """Temporary solution to take into account run arguments provided by users."""
         # Collect all parameters that start with '--' and have a non-None value.
         extra_args = [
-            f'{key}={value}' for key, value in self.mlcube.runner.items() if key.startswith('--') and value is not None
+            f"{key}={value}"
+            for key, value in self.mlcube.runner.items()
+            if key.startswith("--") and value is not None
         ]
-        return ' '.join(extra_args)
+        return " ".join(extra_args)
 
-    def __init__(self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]) -> None:
+    def __init__(
+        self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]
+    ) -> None:
         super().__init__(mlcube, task)
-        if self.mlcube.runner.singularity != 'singularity':
+        self.client = Client(self.mlcube.runner.singularity)
+
+        # Check version and log a warning message if fakeroot is used with singularity version < 3.5
+        if not self.client.supports_fakeroot() and "--fakeroot" in (
+            self.mlcube.runner.build_args or ""
+        ):
             logger.warning(
-                "Singularity executable is not exactly 'singularity' (singularity=%s). The MLCube singularity runner "
-                "will use this executable, however the version of the `spython` library that the runner uses (which is "
-                "`0.2.1`) does not allow specifying a custom singularity executable when checking the singularity "
-                "version. It's OK if `singularity` resolves to` %s`, in other cases this may cause issues.",
-                self.mlcube.runner.singularity, self.mlcube.runner.singularity
-            )
-        try:
-            # Check version and log a warning message if fakeroot is used with singularity version < 3.5
-            version: semver.VersionInfo = get_singularity_version_info()
-            logger.info("SingularityRun singularity version = %s", str(version))
-            if version < semver.VersionInfo(major=3, minor=5) and "--fakeroot" in (
-                self.mlcube.runner.build_args or ""
-            ):
-                logger.warning(
-                    "SingularityRun singularity version < 3.5, and it probably does not support --fakeroot "
-                    "parameter that is present in MLCube configuration."
-                )
-        except Exception as err:
-            # It's correct to use `singularity` here, since the function that identifies the singularity version
-            # does not allow specifying a custom singularity executable (at least in spython == 0.2.1).
-            ver_cmd = f"singularity --version"
-            try:
-                self.check_install(self.mlcube.runner.singularity)
-                msg = "The runner has been able to successfully run the singularity executable (which is "\
-                      f"`{self.mlcube.runner.singularity}`). Most likely, the output of `{ver_cmd}` could not be "\
-                      "parsed. Please, create an issue in MLCube repository and provide the output of "\
-                      f"this command ({ver_cmd})"
-            except:
-                # And here we use the correct executable, since check_install supports user-provided executable.
-                msg = f"The runner has not been able to run this command (`{self.mlcube.runner.singularity} --help`)." \
-                      f"Please check that this executable is in PATH, or specify a custom path in ~/mlcube.yaml."
-            logger.warning(
-                "Singularity runner (cmd=%s) can't detect singularity version. %s. "
-                "Source=SingularityRun.__init__. Exception=%s.", ver_cmd, msg, str(err), exc_info=True
+                "SingularityRun.__init__ singularity runtime (exec=%s, version=%s) does not probably "
+                "support --fakeroot parameter that is present in MLCube configuration.",
+                self.client.singularity,
+                self.client.version,
             )
 
     def configure(self) -> None:
         """Build Singularity Image on a current host."""
-        SingularityRun.check_install(self.mlcube.runner.singularity)
-
         s_cfg: DictConfig = self.mlcube.runner
-
-        # Get full path to a singularity image. By design, we compute it relative to {mlcube.root}/workspace.
-        image_file = Path(s_cfg.image_dir, s_cfg.image)
-        if image_file.exists():
-            logger.info(
-                "SingularityRun SIF exists (%s) - no need to run the configure step.",
-                image_file,
-            )
-            return
-
-        # Make sure a directory to store image exists. If paths are like "/opt/...", the call may fail.
-        image_file.parent.mkdir(parents=True, exist_ok=True)
-
-        build_path = Path(
-            self.mlcube.runtime.root
-        )  # Let's assume that build context is the root MLCube directory
-        recipe: str = s_cfg.build_file  # This is the recipe file, or docker image.
-        if recipe.startswith("docker://") or recipe.startswith("docker-archive:"):
-            # https://sylabs.io/guides/3.0/user-guide/build_a_container.html
-            # URI beginning with docker:// to build from Docker Hub
-            logger.info("SingularityRun building SIF from docker image (%s).", recipe)
-        else:
-            # This must be a recipe file. Make sure it exists.
-            if not Path(build_path, recipe).exists():
-                raise IOError(f"SIF recipe file does not exist (path={build_path}, file={recipe})")
-            logger.info("Building SIF from recipe file (path=%s, file=%s).", build_path, recipe)
-        try:
-            Shell.run([
-                'cd', str(build_path), ';', s_cfg.singularity, 'build', s_cfg.build_args, str(image_file), recipe
-            ])
-        except ExecutionError as err:
-            raise ExecutionError.mlcube_configure_error(
-                self.__class__.__name__,
-                "Error occurred while building SIF image. See context for more details.",
-                **err.context
-            )
+        self.client.build(
+            self.mlcube.runtime.root,
+            s_cfg.build_file,
+            s_cfg.image_dir,
+            s_cfg.image,
+            s_cfg.build_args,
+        )
 
     def run(self) -> None:
         """ """
         image_file = Path(self.mlcube.runner.image_dir) / self.mlcube.runner.image
         if not image_file.exists():
             self.configure()
-        else:
-            SingularityRun.check_install(self.mlcube.runner.singularity)
 
         # Deal with user-provided workspace
         try:
@@ -251,26 +174,29 @@ class SingularityRun(Runner):
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,
                 "Error occurred while syncing MLCube workspace. See context for more details.",
-                error=str(err)
+                error=str(err),
             )
 
         try:
             # The `task_args` list of strings contains task name at the first position.
-            mounts, task_args, mounts_opts = Shell.generate_mounts_and_args(self.mlcube, self.task)
+            mounts, task_args, mounts_opts = Shell.generate_mounts_and_args(
+                self.mlcube, self.task
+            )
             if mounts_opts:
                 for key, value in mounts_opts.items():
-                    mounts[key]+=f':{value}'
-            logger.info(f"mounts={mounts}, task_args={task_args}")
+                    mounts[key] += f":{value}"
+            logger.info(
+                f"SingularityRun.run mounts=%s, task_args=%s", mounts, task_args
+            )
         except ConfigurationError as err:
             raise ExecutionError.mlcube_run_error(
                 self.__class__.__name__,
                 "Error occurred while generating mount points for singularity run command. See context for more "
                 "details and check your MLCube configuration file.",
-                error=str(err)
+                error=str(err),
             )
 
         volumes = Shell.to_cli_args(mounts, sep=":", parent_arg="--bind")
-        print(OmegaConf.to_container(self.mlcube.runner))
         run_args = self.mlcube.runner.run_args
 
         # Temporary solution
@@ -278,23 +204,15 @@ class SingularityRun(Runner):
         if extra_args:
             run_args += " " + extra_args
 
-        try:
-            entrypoint: t.Optional[str] = self.mlcube.tasks[self.task].get('entrypoint', None)
-            if entrypoint:
-                logger.info(
-                    "Using custom task entrypoint: task=%s, entrypoint='%s'",
-                    self.task, self.mlcube.tasks[self.task].entrypoint
-                )
-                Shell.run([self.mlcube.runner.singularity, 'exec', run_args, volumes,
-                           str(image_file), entrypoint, ' '.join(task_args[1:])])
-            else:
-                Shell.run([
-                    self.mlcube.runner.singularity, 'run', run_args, volumes,
-                    str(image_file), ' '.join(task_args)
-                ])
-        except ExecutionError as err:
-            raise ExecutionError.mlcube_run_error(
-                self.__class__.__name__,
-                f"Error occurred while running MLCube task (task={self.task}). See context for more details.",
-                **err.context
+        entrypoint: t.Optional[str] = self.mlcube.tasks[self.task].get(
+            "entrypoint", None
+        )
+        if entrypoint:
+            logger.info(
+                "SingularityRun.run found custom task entrypoint: task=%s, entrypoint='%s'",
+                self.task,
+                self.mlcube.tasks[self.task].entrypoint,
             )
+            # By contract, custom entry points do not accept task name as the first argument.
+            task_args = task_args[1:]
+        self.client.run(run_args, volumes, str(image_file), task_args, entrypoint)

--- a/runners/mlcube_singularity/requirements.txt
+++ b/runners/mlcube_singularity/requirements.txt
@@ -1,2 +1,2 @@
 mlcube==0.0.9
-spython==0.2.1
+semver


### PR DESCRIPTION
This commit mostly introduces the singularity client class. Functionality related to singularity (initialization, getting version, building and running images) previously was implemented in SingularityRun class.

- New Client class (singularity_client.py) that is responsible for working with CLI singularity clients.
- Support for aptainer systems. MLCube singularity runner now correctly parses version string for apptainer.
- New `from_env` method can be used to try to identify what's available (if not specified in system settings file). This function will try something like singularity, apptainer, sudo singularity etc.
- The `spython` dependency is no longer required, and was removed. New dependency (semver) has been added.
- Multiple updates to log messages.
- Upgrading `black` version to the latest (previous version was outdated not supporting new click library).