### PR TITLE
Rebuild documentation when CLI changes.

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -6,6 +6,8 @@ on:
     - '.github/workflows/docs-site.yml'
     - 'docs/**'
     - 'mkdocs.yml'
+    - 'mlcube/mlcube/__main__.py'
+    - 'mlcube/mlcube/cli.py'
 
 jobs:
   docs:


### PR DESCRIPTION
Since web documentation for CLI is generated automatically by the `mkdocs-click`, it needs to be triggered when CLI changes. This commit adds new paths to monitor for changes in order to trigger one of GitHub actions to build and redeploy the documentation pages.