### PR TITLE
Improved experience with MLCube help in console environments.

### DIFF
--- a/mlcube/mlcube/__main__.py
+++ b/mlcube/mlcube/__main__.py
@@ -541,13 +541,14 @@ def config(
     ],  # mlcube config --rename-runner OLD_NAME NEW_NAME
     remove_runner: t.Optional[str],  # mlcube config --remove-runner NAME
 ) -> None:
-    """Work with MLCube [system settings](https://mlcommons.github.io/mlcube/getting-started/system-settings/) similar
-    to `git config`.
+    """Display or change MLCube system settings.
 
-    Manage MLCube system settings (these settings define global configuration common for all MLCube runners and
-    platforms). When this command runs without arguments, a path to system settings file is printed out. This is useful
-    to automate certain operations with system settings. Alternatively, it may be easier to manipulate system settings
-    file directly (it is a yaml file).
+    MLCube [system settings](https://mlcommons.github.io/mlcube/getting-started/system-settings) define global
+    configuration common for all MLCube runners and platforms. When this command runs without arguments, a path to
+    system settings file is printed out. This is useful to automate certain operations with system settings.
+    system settings file is printed out. This is useful to automate certain operations with system settings.
+
+    Alternatively, it may be easier to manipulate system settings file directly (it is a yaml file).
     """
     print(f"System settings file path = {SystemSettings.system_settings_file()}")
     settings = SystemSettings()


### PR DESCRIPTION
- Updating documentation for config command.
- Various improvements in command line-based help pages:
  - Fixing bugs related in markdown-to-text conversion.
  - Keeping code blocks as is in textual format (wrapped with ``, e.g., `pip install cookiecutter`).
  - Introducing new and renaming existing sections in console-based help messages: "Brief description", "Long description", "Options" and "Examples".
  - The doc strings can now contain on <long>very long description</long> block. This will not be part of console-based help, but will be part of web-based documentation pages.
  - Simplifying logic that's used to print epilogues (example usages).