### PR TITLE
Switch to Trusted Publisher method for PyPi releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -89,6 +89,6 @@ More Information on python-publish action & Repository Dispatch action can be fo
 ### Secrets used
 | Name  |   |
 |---|---|
-|PYPI_USER        |pypi login credentials used in GitHub workflows    |
-|PYPI_PASSWORD    |pypi login credentials used in GitHub workflows    |
+|PYPI_USER (depreciated)        |pypi login credentials used in GitHub workflows    |
+|PYPI_PASSWORD (depreciated)    |pypi login credentials used in GitHub workflows    |
 |MLCOMMONS_REPO_ACCESS   |public_repo ACL for request dispatch in GitHub workflows  |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -29,10 +29,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: mlcube/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: mlcube/dist/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.MLCOMMONS_REPO_ACCESS }}
           repository: mlcommons/mlcube

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -27,10 +29,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: mlcube/dist/
         repository_url: https://upload.pypi.org/legacy/
         verbose: true

--- a/.github/workflows/runner-publish.yml
+++ b/.github/workflows/runner-publish.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -29,10 +29,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: runners/mlcube_ssh/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: runners/mlcube_ssh/dist/
+        repository-url: https://upload.pypi.org/legacy/
       env:
         LOGLEVEL: DEBUG
 
@@ -41,9 +41,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -57,10 +57,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: runners/mlcube_docker/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: runners/mlcube_docker/dist/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG
@@ -70,9 +70,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -86,10 +86,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: runners/mlcube_singularity/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: runners/mlcube_singularity/dist/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG
@@ -99,9 +99,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -115,10 +115,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: runners/mlcube_k8s/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: runners/mlcube_k8s/dist/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG
@@ -128,9 +128,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -144,10 +144,10 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        verify_metadata: true
-        skip_existing: true
-        packages_dir: runners/mlcube_gcp/dist/
-        repository_url: https://upload.pypi.org/legacy/
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: runners/mlcube_gcp/dist/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG
@@ -157,9 +157,9 @@ jobs:
       permissions:
         id-token: write
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -173,10 +173,10 @@ jobs:
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          verify_metadata: true
-          skip_existing: true
-          packages_dir: runners/mlcube_kubeflow/dist/
-          repository_url: https://upload.pypi.org/legacy/
+          verify-metadata: true
+          skip-existing: true
+          packages-dir: runners/mlcube_kubeflow/dist/
+          repository-url: https://upload.pypi.org/legacy/
           verbose: true
         env:
           LOGLEVEL: DEBUG

--- a/.github/workflows/runner-publish.yml
+++ b/.github/workflows/runner-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   ssh_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -27,10 +29,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: runners/mlcube_ssh/dist/
         repository_url: https://upload.pypi.org/legacy/
       env:
@@ -38,6 +38,8 @@ jobs:
 
   docker_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -55,10 +57,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: runners/mlcube_docker/dist/
         repository_url: https://upload.pypi.org/legacy/
         verbose: true
@@ -67,6 +67,8 @@ jobs:
 
   singularity_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -84,10 +86,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: runners/mlcube_singularity/dist/
         repository_url: https://upload.pypi.org/legacy/
         verbose: true
@@ -96,6 +96,8 @@ jobs:
 
   kubernetes_runner_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -113,10 +115,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: runners/mlcube_k8s/dist/
         repository_url: https://upload.pypi.org/legacy/
         verbose: true
@@ -125,6 +125,8 @@ jobs:
 
   gcp_runner_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -142,10 +144,8 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
         verify_metadata: true
         skip_existing: true
-        password: ${{ secrets.PYPI_PASSWORD }}
         packages_dir: runners/mlcube_gcp/dist/
         repository_url: https://upload.pypi.org/legacy/
         verbose: true
@@ -154,6 +154,8 @@ jobs:
 
   kubeflow_runner_deploy:
       runs-on: ubuntu-latest
+      permissions:
+        id-token: write
       steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -171,10 +173,8 @@ jobs:
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USER }}
           verify_metadata: true
           skip_existing: true
-          password: ${{ secrets.PYPI_PASSWORD }}
           packages_dir: runners/mlcube_kubeflow/dist/
           repository_url: https://upload.pypi.org/legacy/
           verbose: true


### PR DESCRIPTION
For publishing releases to PyPi, this PR switches from authenticating with user credentials to using the [Trusted Publisher method](https://docs.pypi.org/trusted-publishers/).

Following [this documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/) for changes to the publish workflows.

Also normalized to kebab-case and updated some actions to move from Node12 to Node16.

Tested with TestPyPi in a [forked repo](https://github.com/nathanw-mlc/mlcube).