### PR TITLE
Correct version parsing for singularity-ce.

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
@@ -142,6 +142,11 @@ class Client:
                     Runtime.SINGULARITY,
                     version_string[20:].strip(),
                 )
+            elif version_string.startswith("singularity-ce version "):
+                runtime, version_string = (
+                    Runtime.SINGULARITY,
+                    version_string[23:].strip(),
+                )
             elif version_string.startswith("apptainer version "):
                 runtime, version_string = Runtime.APPTAINER, version_string[18:].strip()
             elif "/" in version_string:  # Handle old stuff like "x.y.z-pull/123-0a5d"


### PR DESCRIPTION
Community edition of singularity starting version 3.8.0 (https://github.com/sylabs/singularity/releases?page=4) changes its name to `singularity-ce`. This commit adds support for version strings that looks like `singularity-ce version 3.10.0`.