### PR TITLE
Parse `short` docker image names correctly.

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_client.py
@@ -86,15 +86,16 @@ class DockerImage:
         # Determine if first part is a host/port pair
         host: t.Optional[str] = None
         port: t.Optional[int] = None
-        if parts[0] == "localhost":
-            host = parts[0]
-        if "." in parts[0]:
-            host_port: t.List[str] = parts[0].split(":")
-            host = host_port[0]
-            if len(host_port) > 1:
-                port = int(host_port[1])
-        if host is not None:
-            del parts[0]
+        if len(parts) > 1:
+            if parts[0] == "localhost":
+                host = parts[0]
+            elif "." in parts[0]:
+                host_port: t.List[str] = parts[0].split(":")
+                host = host_port[0]
+                if len(host_port) > 1:
+                    port = int(host_port[1])
+            if host is not None:
+                del parts[0]
 
         # See of digest is present (must be checked first since it can include ":", e.g., @sha256:dt3...)
         digest: t.Optional[str] = None

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_client.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_client.py
@@ -2,8 +2,7 @@ import typing as t
 from unittest import TestCase
 
 import semver
-from mlcube_singularity.singularity_client import (Client, DockerImage,
-                                                   Runtime, Version)
+from mlcube_singularity.singularity_client import Client, DockerImage, Runtime, Version
 
 
 class TestSingularityRunner(TestCase):
@@ -164,6 +163,13 @@ class TestSingularityRunner(TestCase):
                 digest="sha256:9b77d4cb97f8dcf14ac137bf65185fc8980578",
             ),
         )
+        self.check_docker_image(
+            DockerImage.from_string("ubuntu:18.04"),
+            DockerImage(
+                path=["ubuntu"],
+                tag="18.04",
+            ),
+        )
 
     def test_docker_image_to_string(self) -> None:
         names: t.List[t.Union[t.Tuple[str, str], str]] = [
@@ -177,5 +183,7 @@ class TestSingularityRunner(TestCase):
             "mlcommons/hello_world@sha256:9b77d4cb97f8dcf14ac137bf65185fc8980578",
         ]
         for name in names:
-            name_in, name_out = (name, name) if isinstance(name, str) else (name[0], name[1])
+            name_in, name_out = (
+                (name, name) if isinstance(name, str) else (name[0], name[1])
+            )
             self.assertEqual(str(DockerImage.from_string(name_in)), name_out)


### PR DESCRIPTION
This commit fixes the parsing of `short` docker image names such as `ubuntu:18.04` (previous version incorrectly tries to parse it as `host:port` pair).