### PR TITLE
Fixing CLI commands fail when `mount` option not present.

### DIFF
--- a/mlcube/mlcube/parser.py
+++ b/mlcube/mlcube/parser.py
@@ -139,7 +139,8 @@ class CliParser(object):
             if parsed_args.get("cpu", None):
                 key = "--cpuset-cpus" if platform == "docker" else "--vm-cpu"
                 runner_run_args[key] = parsed_args["cpu"]
-            runner_run_args["--mount_opts"] = parsed_args["mount"]
+            if parsed_args.get("mount", None):
+                runner_run_args["--mount_opts"] = parsed_args["mount"]
 
             mlcube_args.merge_with({platform: runner_run_args})
 


### PR DESCRIPTION
The parser checks if certain CLI arguments present before accessing them. One of previous commits that introduced new `mount` options was not checking for this, and was accessing mount option directly. That was causing no such key error. This commit fixes it.