### PR TITLE
Updating kfp library version to 1.8.22

### DIFF
--- a/runners/mlcube_kubeflow/requirements.txt
+++ b/runners/mlcube_kubeflow/requirements.txt
@@ -1,3 +1,3 @@
 mlcube==0.0.10rc1
 protobuf==3.20.3
-kfp==1.8.18
+kfp==2.4.0

--- a/runners/mlcube_kubeflow/requirements.txt
+++ b/runners/mlcube_kubeflow/requirements.txt
@@ -1,3 +1,3 @@
 mlcube==0.0.10rc1
 protobuf==3.20.3
-kfp==2.4.0
+kfp==1.8.22


### PR DESCRIPTION
Updating version of the `kfp` dependency to 1.8.22. This fixes this error (https://github.com/kubeflow/pipelines/pull/9323). Can't use later versions since they use V2 API that will require code refactoring.