### PR TITLE
Updating GPU (accelerator) support in MLCube.

### DIFF
--- a/mlcube/mlcube/tests/test_parser.py
+++ b/mlcube/mlcube/tests/test_parser.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 
 from omegaconf import DictConfig, OmegaConf
 
-from mlcube.parser import CliParser, MLCubeDirectory
+from mlcube.errors import ConfigurationError
+from mlcube.parser import CliParser, MLCubeDirectory, DeviceSpecs
 
 
 class TestParser(TestCase):
@@ -151,5 +152,165 @@ class TestParser(TestCase):
             },
             expected_task_args={},
         )
-        self.assertIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
-        self.assertEqual(os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"], "GPUS_2")
+        # self.assertIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
+        # self.assertEqual(os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"], "GPUS_2")
+
+
+class TestDeviceSpecs(TestCase):
+    def _check_val(self, actual: t.Optional = None, expected: t.Optional = None) -> None:
+        if expected is None:
+            self.assertIsNone(actual)
+        else:
+            self.assertEqual(expected, actual)
+
+    def _check_device(
+            self, device: DeviceSpecs.Device, index: t.Optional[int] = None, uuid: t.Optional[str] = None
+    ) -> None:
+        self.assertIsInstance(device, DeviceSpecs.Device)
+        self._check_val(device.index, index)
+        self._check_val(device.uuid, uuid)
+
+    def test_device_init(self) -> None:
+        device = DeviceSpecs.Device()
+        self.assertIsNone(device.index)
+        self.assertIsNone(device.uuid)
+
+        device = DeviceSpecs.Device(index=1)
+        self.assertEqual(1, device.index)
+        self.assertIsNone(device.uuid)
+
+        device = DeviceSpecs.Device(uuid="GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7")
+        self.assertIsNone(device.index)
+        self.assertEqual("GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7", device.uuid)
+
+    def test_device_create(self) -> None:
+        device = DeviceSpecs.Device.create("2")
+        self.assertEqual(2, device.index)
+        self.assertIsNone(device.uuid)
+
+        device = DeviceSpecs.Device.create("GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7")
+        self.assertIsNone(device.index)
+        self.assertEqual("GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7", device.uuid)
+
+    def _check_none(self, specs: DeviceSpecs) -> None:
+        self.assertIsInstance(specs, DeviceSpecs)
+        self.assertIsInstance(str(specs), str)
+        self.assertTrue(specs.none is not None and specs.none is True)
+        self.assertTrue(specs.all is not None and specs.all is False)
+        self.assertIsNone(specs.num_devices)
+        self.assertIsNone(specs.devices)
+
+    def _check_devices_specified(self, specs: DeviceSpecs) -> None:
+        self.assertIsInstance(specs, DeviceSpecs)
+        self.assertIsInstance(str(specs), str)
+        self.assertTrue(specs.none is not None and specs.none is False)
+        self.assertTrue(specs.all is not None and specs.all is False)
+        self.assertIsNone(specs.num_devices)
+        self.assertIsInstance(specs.devices, list)
+        self.assertTrue(len(specs.devices) > 0)
+        for device in specs.devices:
+            self.assertIsInstance(device, DeviceSpecs.Device)
+
+    def test_init(self) -> None:
+        self._check_none(DeviceSpecs())
+
+    def test_none(self) -> None:
+        for gpus in (None, "", "   ", "0"):
+            self._check_none(DeviceSpecs.from_string(gpus))
+
+    def test_all(self) -> None:
+        specs = DeviceSpecs.from_string("all")
+        self.assertTrue(specs.none is not None and specs.none is False)
+        self.assertTrue(specs.all is not None and specs.all is True)
+        self.assertIsNone(specs.num_devices)
+        self.assertIsNone(specs.devices)
+
+    def test_num_devices(self) -> None:
+        for num_devices in (1, 3, 5):
+            specs = DeviceSpecs.from_string(f"{num_devices}")
+            self.assertTrue(specs.none is not None and specs.none is False)
+            self.assertTrue(specs.all is not None and specs.all is False)
+            self.assertTrue(specs.num_devices is not None and specs.num_devices == num_devices)
+            self.assertIsNone(specs.devices)
+
+    def test_devices(self) -> None:
+        specs = DeviceSpecs.from_string("device=1")
+        self._check_devices_specified(specs)
+        self.assertEqual(1, len(specs.devices))
+        self._check_device(specs.devices[0], index=1, uuid=None)
+
+        specs = DeviceSpecs.from_string("device=2,3")
+        self._check_devices_specified(specs)
+        self.assertEqual(2, len(specs.devices))
+        self._check_device(specs.devices[0], index=2, uuid=None)
+        self._check_device(specs.devices[1], index=3, uuid=None)
+
+        specs = DeviceSpecs.from_string("device=GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7")
+        self._check_devices_specified(specs)
+        self.assertEqual(1, len(specs.devices))
+        self._check_device(specs.devices[0], index=None, uuid="GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7")
+
+        specs = DeviceSpecs.from_string("device=GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7,7")
+        self._check_devices_specified(specs)
+        self.assertEqual(2, len(specs.devices))
+        self._check_device(specs.devices[0], index=None, uuid="GPU-1f22a253-c329-dfb7-0db4-e005efb6a4c7")
+        self._check_device(specs.devices[1], index=7, uuid=None)
+
+        # Check that exception is raised when device list is provided without `device=` prefix.
+        self.assertRaises(
+            ConfigurationError,
+            DeviceSpecs.from_string,
+            gpus="0,1,2"
+        )
+
+    def _check_docker_specs(
+            self, specs: DeviceSpecs.DockerSpecs, gpus: t.Optional[str] = None,
+            cuda_visible_devices: t.Optional[str] = None
+    ) -> None:
+        self.assertIsInstance(specs, DeviceSpecs.DockerSpecs)
+        self._check_val(specs.gpus, gpus)
+        self._check_val(specs.cuda_visible_devices, cuda_visible_devices)
+
+    def test_get_docker_specs(self) -> None:
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus=None, cuda_visible_devices=None)
+
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("all").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus="all", cuda_visible_devices=None)
+
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("1").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus="1", cuda_visible_devices="0")
+
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("3").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus="3", cuda_visible_devices="0,1,2")
+
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("device=3").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus="device=3", cuda_visible_devices="0")
+
+        docker_specs: DeviceSpecs.DockerSpecs = DeviceSpecs.from_string("device=7,GPU-UUID").get_docker_specs()
+        self._check_docker_specs(docker_specs, gpus="device=7,GPU-UUID", cuda_visible_devices="0,1")
+
+    def test_check_with_platform_specs(self) -> None:
+        """Run all execution paths to check does not crash."""
+        for accelerator_count in (None, -1):
+            DeviceSpecs().check_with_platform_specs(accelerator_count=accelerator_count)
+
+        for gpus in ("", "1"):
+            DeviceSpecs.from_string(gpus).check_with_platform_specs(accelerator_count=0)
+
+        for gpus in ("all", "2", "device=4,5", "1", "device=2", "device=5,6,7"):
+            DeviceSpecs.from_string(gpus).check_with_platform_specs(accelerator_count=2)
+
+    def test_from_config(self) -> None:
+        for count in (None, 0, -1):
+            specs = DeviceSpecs.from_config(accelerator_count=count, gpus=None)
+            self.assertTrue(specs.none)
+
+        for num_dev in (1, 3):
+            # This must set GPUs spec.
+            specs = DeviceSpecs.from_config(accelerator_count=num_dev, gpus=None)
+            self.assertIsNotNone(specs.num_devices)
+            self.assertEqual(num_dev, specs.num_devices)
+            # Check that we can override and disable GPUs
+            for gpus in ("", "0"):
+                self.assertTrue(DeviceSpecs.from_config(accelerator_count=num_dev, gpus=gpus).none)


### PR DESCRIPTION
This commit changes how MLCube runtime works with GPUs. Users have two options to provide information on required accelerators:
- It can be done in MLCube configuration file in the `platform` section (platform.accelerator_count). This value is optional, and if present, may be an empy / non-set string, or an integer. This values is the number of required accelerators, and semantically, is equivalent to docker's `--gpu=N` CLI argument.
- It can be done on a command line using `--gpus` argument, e.g., `mlcube run ... --gpus=4`. This parameter accepts same values as docker's `--gpus` CLI argument does. Concretely:
  - When not set MLCube will use platform.accelerator_count value if present.
  - When set, this overrides any value assigned to platform.accelerator_count. Could be empty (`--gpus=`) to disable GPUs, all (`--gpus=all`) to use all available GPUs, GPU count (`--gpus=N`) or list of concrete GPUs (`--gpus="device=0,2"`). In this list GPU indices or UUIDs can be used.

Docker runner will pretty much use this value unmodified and will pass it to docker run command, e.g., `--gpus` flag will present. Singularity runner will pass `--nv` command when GPUs are requested. No CUDA_VISIBLE_DEVICES, SINGULARITYENV_CUDA_VISIBLE_DEVICES or any other env variable will be set by MLCube runtime (docker NVIDIA runtime may set NVIDIA_VISIBLE_DEVICES).

To debug for possble issues, enable debug mode (e.g., `mlcube --log-level=debug run ...`) and search the output for the log lines that contain `DEBUG Device spec (...) resolved to ...` and `INFO Device params ... resolved to ...`. They will provide additional information on how MLCube runtime determines how GPUs should be used.