### PR TITLE
Initial commit for supporting CLI singularity arguments when input for singularity runner is docker configuration.

### DIFF
--- a/mlcube/mlcube/shell.py
+++ b/mlcube/mlcube/shell.py
@@ -124,7 +124,9 @@ class Shell(object):
         """
         try:
             exit_code = 0
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            if isinstance(output, bytes):
+                output = output.decode()
         except FileNotFoundError as err:
             exit_code, output = 1, str(err)
         except subprocess.CalledProcessError as err:

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_config.py
@@ -8,17 +8,19 @@ from omegaconf import OmegaConf
 class TestConfig(TestCase):
     def test_merge(self) -> None:
         scfg = {'image': 'mnist-0.0.1.sif', 'image_dir': '/path/to/image', 'singularity': 'singularity'}
+        runtime = {'workspace': '/path/to/workspace', 'root': '/path/to/root'}
         config = OmegaConf.create({
             'singularity': scfg,
-            'runtime': {'workspace': '/path/to/workspace'}
+            'runtime': runtime,
+            'runner': Config.DEFAULT
         })
         Config.merge(config)
         self.assertEqual(
             config,
             OmegaConf.create({
-                'runner': scfg,
+                'runner': OmegaConf.merge(Config.DEFAULT, scfg),
                 'singularity': scfg,
-                'runtime': {'workspace': '/path/to/workspace'}
+                'runtime': runtime
             })
         )
 

--- a/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
+++ b/runners/mlcube_singularity/mlcube_singularity/tests/test_singularity_runner.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 import typing as t
 import unittest
+from io import open
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import mock_open, patch
@@ -25,6 +26,7 @@ from omegaconf import DictConfig, OmegaConf
 from mlcube.config import MLCubeConfig
 from mlcube.errors import ExecutionError
 from mlcube.shell import Shell
+
 
 try:
     client = Client.from_env()
@@ -57,6 +59,33 @@ tasks:
 """.replace(
     "{IMAGE_DIRECTORY}", _IMAGE_DIRECTORY.as_posix()
 )
+
+
+_MLCUBE_CONFIG_FILE = "/some/path/to/mlcube.yaml"
+"""We will be mocking io.open call only for this file path."""
+
+_io_open = open
+"""Original function we will be mocking in these unit tests."""
+
+
+def get_custom_mock_open(file_path_to_mock: str, read_data: str) -> t.Callable:
+    """Function to help mock `io.open` only for this specific file path.
+
+    Original implementation:
+    https://stackoverflow.com/questions/67234524/python-unittest-mock-open-specific-paths-dont-mock-others
+
+    Args:
+        file_path_to_mock: Only mock the `io.open` call for this path. For others, call original `io.open`.
+        read_data: Content for the `file_path_to_mock` file.
+
+    """
+    def mocked_open() -> t.Callable:
+        def conditional_open_fn(path, *args, **kwargs):
+            if path == file_path_to_mock:
+                return mock_open(read_data=read_data)()
+            return _io_open(path, *args, **kwargs)
+        return conditional_open_fn
+    return mocked_open
 
 
 _sync_workspace_fn: t.Optional[t.Callable] = None
@@ -102,9 +131,9 @@ class TestSingularityRunner(TestCase):
 
     @unittest.skipUnless(client is not None, reason="No singularity available.")
     def test_mlcube_default_entrypoints(self):
-        with patch("io.open", mock_open(read_data=_MLCUBE_DEFAULT_ENTRY_POINT)):
+        with patch("io.open", new_callable=get_custom_mock_open(_MLCUBE_CONFIG_FILE, _MLCUBE_DEFAULT_ENTRY_POINT)):
             mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-                "/some/path/to/mlcube.yaml",
+                _MLCUBE_CONFIG_FILE,
                 runner_config=Config.DEFAULT,
                 runner_cls=SingularityRun,
             )
@@ -122,9 +151,9 @@ class TestSingularityRunner(TestCase):
 
     @unittest.skipUnless(client is not None, reason="No singularity available.")
     def test_mlcube_custom_entrypoints(self):
-        with patch("io.open", mock_open(read_data=_MLCUBE_CUSTOM_ENTRY_POINTS)):
+        with patch("io.open", new_callable=get_custom_mock_open(_MLCUBE_CONFIG_FILE, _MLCUBE_CUSTOM_ENTRY_POINTS)):
             mlcube: DictConfig = MLCubeConfig.create_mlcube_config(
-                "/some/path/to/mlcube.yaml",
+                _MLCUBE_CONFIG_FILE,
                 runner_config=Config.DEFAULT,
                 runner_cls=SingularityRun,
             )


### PR DESCRIPTION
This PR fixes #343.

## Brief description
This commit reimplements the logic that singularity runner uses to determine its configuration when it is not fully specified.
- If `singularity` section not present, a new one, empty, is created.
- If SIF file path can be identified, and the file exists, configuration is considered to be complete. For this to happen, `image` key must be present.
- If recipe (`build_file`) can be identified, and it's either a docker image or an existing singularity recipe file, configuration is considered to be complete. If `image` not present, it is added.
- Finally, docker configuration is used to identify build source (build_file will point to docker image or tar file) and `image`. Additionally, to be consistent with prev implementation `singularity` and `build_args` maybe overridden.

## Known issue
If during the configure phase, an error occurs, you may need (depending on error)
- Either install uidmap `sudo apt-get install uidmap`.
- Overwrite `build_args` to disable `--fakeroot` singularity build argument that may be set automatically (e.g., mlcube run ... -Psingularity.build_args="''"). Pay attention that value (for now) must include two single quotes.

## Enabling detailed log
Set log level to `debug`: `mlcube --log-level=debug ...`.