### PR TITLE
Singularity flags bugfix.

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -186,12 +186,17 @@ class SingularityRun(Runner):
     def _get_extra_args(self) -> str:
         """Temporary solution to take into account run arguments provided by users."""
         # Collect all parameters that start with '--' and have a non-None value.
-        extra_args = [
-            f"{key}={value}"
-            for key, value in self.mlcube.runner.items()
-            if key.startswith("--") and value is not None and key != "--mount_opts"
-        ]
-        return " ".join(extra_args)
+        flags = {"--nv"}             # These do not require value.
+        ignored = {"--mount_opts"}   # Ignore these arguments.
+
+        extra_args: t.List[str] = []
+        for key, value in self.mlcube.runner.items():
+            if key.startswith("--") and value is not None and key not in ignored:
+                extra_args.append(key if key in flags else f"{key}={value}")
+
+        extra_args_as_str = " ".join(extra_args)
+        logger.debug("SingularityRun._get_extra_args extra_args='%s'.", extra_args_as_str)
+        return extra_args_as_str
 
     def __init__(
         self, mlcube: t.Union[DictConfig, t.Dict], task: t.Optional[str]


### PR DESCRIPTION
This commit fixes bug that prevents singularity runner to form the correct command line to run singularity-based mlcubes. Concretely, singularity runner now correctly processes command line arguments that requrie values (such as `--security`) and those that do not (flags such as `--nv`).