### PR TITLE
Correct processing when `build-args` is empty (none).

### DIFF
--- a/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
+++ b/runners/mlcube_singularity/mlcube_singularity/singularity_run.py
@@ -223,7 +223,7 @@ class SingularityRun(Runner):
             recipe=s_cfg.build_file,
             image_dir=s_cfg.image_dir,
             image_name=s_cfg.image,
-            build_args=s_cfg.build_args,
+            build_args=s_cfg.build_args or "",
         )
 
     def run(self) -> None:


### PR DESCRIPTION
In certain scenarios when singularity runner is used, setting `build_args` to empty string (-Psingularity.build_args="") results in error (accessign variable that's None). This commit fixes it.