### PR TITLE
Fixing MLCube and KubeFlow runner for python 3.6.

### DIFF
--- a/mlcube/requirements.txt
+++ b/mlcube/requirements.txt
@@ -1,5 +1,6 @@
 click>=8.0.0,<9.0.0
 coloredlogs==14.0
-cookiecutter==2.1.1
+cookiecutter==1.7.3;python_version<"3.7"
+cookiecutter==2.1.1;python_version>="3.7"
 omegaconf==2.1.0
 markdown

--- a/runners/mlcube_kubeflow/requirements.txt
+++ b/runners/mlcube_kubeflow/requirements.txt
@@ -1,3 +1,7 @@
 mlcube==0.0.10rc2
-protobuf==3.20.3
-kfp==1.8.22
+protobuf==3.19.6;python_version<"3.7"
+protobuf==3.20.3;python_version>="3.7"
+
+# For p3.6 we need https://pypi.org/project/kfp-pipeline-spec/0.1.13/ python >=3.5.3
+kfp==1.8.5;python_version<"3.7"
+kfp==1.8.22;python_version>="3.7"


### PR DESCRIPTION
To use MLCube ecosystem with Python 3.6, the following is introduced in this commit:

## MLCube
- The cookiecutter version is downgraded for python 3.6, for 3.7 and above it remains as it was before - 2.1.1.

## KubeFlow runner
- The protobuf version is downgraded to 3.19.6 for python 3.6, for 3.7 and above it remains as it was before - 3.20.3.
- The kfp version is downgraded to 1.8.5 for python 3.6, for 3.7 and above it remains as it was before - 1.8.22.