### PR TITLE
Forcing pip to 24.0 version in GitHub workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           python-version: 3.8.5
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          # FIX sergey https://github.com/mlcommons/mlcube/issues/360
+          # python -m pip install --upgrade pip
+          python -m pip install pip==24.0
           pip install setuptools wheel
           pip install -r ./requirements-test.txt
       - name: Install MLCube

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -20,7 +20,9 @@ jobs:
           python-version: '3.8'
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          # FIX sergey https://github.com/mlcommons/mlcube/issues/360
+          # python -m pip install --upgrade pip
+          python -m pip install pip==24.0
           pip install -r docs/requirements.txt
       - name: Build Docs
         working-directory: './'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,9 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        # FIX sergey https://github.com/mlcommons/mlcube/issues/360
+        # python -m pip install --upgrade pip
+        python -m pip install pip==24.0
         pip install setuptools wheel twine
     - name: Build distribution
       run: |

--- a/.github/workflows/runner-publish.yml
+++ b/.github/workflows/runner-publish.yml
@@ -20,7 +20,9 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        # FIX sergey https://github.com/mlcommons/mlcube/issues/360
+        # python -m pip install --upgrade pip
+        python -m pip install pip==24.0
         pip install setuptools wheel twine
     - name: Build distribution
       run: |


### PR DESCRIPTION
Latest pip (`24.1`, released on 06/20/2024) does not install `omegaconf==2.1.0` due to non-standard metadata:

```
DEPRECATION: omegaconf 2.1.0 has a non-standard dependency specifier PyYAML>=5.1.*. pip 24.1 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of omegaconf or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063
```
GitHub workflows fail due to this reason. Temporarily, I have updated workflow files to use pip 24.0 until this is fixed. The following files are modified - _ci.yml_, _runner-publish.yml_, _docs-site.yml_ and _python-publish.yml_.